### PR TITLE
Add SECURITY.md file that documents the repo security policies.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by email to `security@langchain.dev`.
+This email is an alias to a subset of our maintainers, and will ensure the issue is promptly triaged and acted upon as needed.


### PR DESCRIPTION
Adding this file populates the GitHub Security tab's security policy field, letting users know where to report issues.
