### PR TITLE
Add auth options for RemoteRunnable

### DIFF
--- a/langserve/client.py
+++ b/langserve/client.py
@@ -142,7 +142,7 @@ class RemoteRunnable(Runnable[Input, Output]):
             cookies=cookies,
             verify=verify,
             cert=cert,
-            **client_kwargs,
+            **_client_kwargs,
         )
         self.async_client = httpx.AsyncClient(
             base_url=url,
@@ -152,7 +152,7 @@ class RemoteRunnable(Runnable[Input, Output]):
             cookies=cookies,
             verify=verify,
             cert=cert,
-            **client_kwargs,
+            **_client_kwargs,
         )
 
         # Register cleanup handler once RemoteRunnable is garbage collected

--- a/langserve/client.py
+++ b/langserve/client.py
@@ -15,6 +15,8 @@ from typing import (
 from urllib.parse import urljoin
 
 import httpx
+from httpx._types import CertTypes, CookieTypes, HeaderTypes, VerifyTypes, AuthTypes
+
 from langchain.callbacks.tracers.log_stream import RunLog, RunLogPatch
 from langchain.load.dump import dumpd
 from langchain.schema.runnable import Runnable
@@ -110,16 +112,42 @@ class RemoteRunnable(Runnable[Input, Output]):
         url: str,
         *,
         timeout: Optional[float] = None,
+        auth: Optional[AuthTypes] = None,
+        headers: Optional[HeaderTypes] = None,
+        cookies: Optional[CookieTypes] = None,
+        verify: VerifyTypes = True,
+        cert: Optional[CertTypes] = None,
     ) -> None:
         """Initialize the client.
 
         Args:
             url: The url of the server
             timeout: The timeout for requests
+            auth: Authentication class for requests
+            headers: Headers to send with requests
+            cookies: Cookies to send with requests
+            verify: Whether to verify SSL certificates
+            cert: SSL certificate to use for requests
         """
         self.url = url
-        self.sync_client = httpx.Client(base_url=url, timeout=timeout)
-        self.async_client = httpx.AsyncClient(base_url=url, timeout=timeout)
+        self.sync_client = httpx.Client(
+            base_url=url,
+            timeout=timeout,
+            auth=auth,
+            headers=headers,
+            cookies=cookies,
+            verify=verify,
+            cert=cert,
+        )
+        self.async_client = httpx.AsyncClient(
+            base_url=url,
+            timeout=timeout,
+            auth=auth,
+            headers=headers,
+            cookies=cookies,
+            verify=verify,
+            cert=cert
+        )
 
         # Register cleanup handler once RemoteRunnable is garbage collected
         weakref.finalize(self, _close_clients, self.sync_client, self.async_client)

--- a/langserve/client.py
+++ b/langserve/client.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import (
     Any,
     AsyncIterator,
+    Dict,
     Iterator,
     List,
     Optional,
@@ -15,8 +16,7 @@ from typing import (
 from urllib.parse import urljoin
 
 import httpx
-from httpx._types import CertTypes, CookieTypes, HeaderTypes, VerifyTypes, AuthTypes
-
+from httpx._types import AuthTypes, CertTypes, CookieTypes, HeaderTypes, VerifyTypes
 from langchain.callbacks.tracers.log_stream import RunLog, RunLogPatch
 from langchain.load.dump import dumpd
 from langchain.schema.runnable import Runnable
@@ -117,6 +117,7 @@ class RemoteRunnable(Runnable[Input, Output]):
         cookies: Optional[CookieTypes] = None,
         verify: VerifyTypes = True,
         cert: Optional[CertTypes] = None,
+        client_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Initialize the client.
 
@@ -128,7 +129,10 @@ class RemoteRunnable(Runnable[Input, Output]):
             cookies: Cookies to send with requests
             verify: Whether to verify SSL certificates
             cert: SSL certificate to use for requests
+            client_kwargs: If provided will be unpacked as kwargs to both the sync
+                           and async httpx clients
         """
+        _client_kwargs = client_kwargs or {}
         self.url = url
         self.sync_client = httpx.Client(
             base_url=url,
@@ -138,6 +142,7 @@ class RemoteRunnable(Runnable[Input, Output]):
             cookies=cookies,
             verify=verify,
             cert=cert,
+            **client_kwargs,
         )
         self.async_client = httpx.AsyncClient(
             base_url=url,
@@ -146,7 +151,8 @@ class RemoteRunnable(Runnable[Input, Output]):
             headers=headers,
             cookies=cookies,
             verify=verify,
-            cert=cert
+            cert=cert,
+            **client_kwargs,
         )
 
         # Register cleanup handler once RemoteRunnable is garbage collected


### PR DESCRIPTION
This PR adds support for most authentication scenarios to `RemoteRunnable`.  It does this by exposing auth kwargs available in the `httpx` clients.

From the [httpx source](https://github.com/encode/httpx/blob/master/httpx/_client.py#L582):
* **auth** - *(optional)* An authentication class to use when sending requests.
* **headers** - *(optional)* Dictionary of HTTP headers to include when sending requests.
* **cookies** - *(optional)* Dictionary of Cookie items to include when sending requests.
* **verify** - *(optional)* SSL certificates (a.k.a CA bundle) used to verify the identity of requested hosts. Either `True` (default CA bundle), a path to an SSL certificate file, an `ssl.SSLContext`, or `False` (which will disable verification).
* **cert** - *(optional)* An SSL certificate used by the requested host to authenticate the client. Either a path to an SSL certificate file, or two-tuple of (certificate file, key file), or a three-tuple of (certificate file, key file, password).

## Testing
- [ ] what tests are needed?

