### PR TITLE
Not able to serialize object id from mongodb

### DIFF
--- a/langserve/serialization.py
+++ b/langserve/serialization.py
@@ -22,6 +22,7 @@ from langchain.schema.messages import (
     SystemMessage,
     SystemMessageChunk,
 )
+from bson import ObjectId
 
 try:
     from pydantic.v1 import BaseModel, ValidationError
@@ -64,6 +65,8 @@ class _LangChainEncoder(json.JSONEncoder):
     def default(self, obj) -> Any:
         if isinstance(obj, BaseModel):
             return obj.dict()
+        if isinstance(obj, ObjectId):
+            return str(obj)
         return super().default(obj)
 
 


### PR DESCRIPTION
Encountered this issue when using the stream endpoint only.  The invoke endpoint seems to work without this change.  An alternative is to not detecting the Object Id and treat everything like a plain string.  

I could offer the mongodb chain in PM if needed.  ty 