### PR TITLE
Fix bug for adding routes to APIRouter

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -327,7 +327,10 @@ def add_routes(
             "Use `pip install sse_starlette` to install."
         )
 
-    _register_path_for_app(app, path)
+    if isinstance(app, FastAPI):  # type: ignore
+        # Cannot do this checking logic for a router since
+        # API routers are not hashable
+        _register_path_for_app(app, path)
     well_known_lc_serializer = WellKnownLCSerializer()
 
     if hasattr(app, "openapi_tags") and app not in _APP_SEEN:

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 import httpx
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 from langchain.callbacks.tracers.log_stream import RunLogPatch
@@ -1221,3 +1221,21 @@ async def test_custom_user_type() -> None:
         app, path="/foo", raise_app_exceptions=False
     ) as runnable:
         assert await runnable.ainvoke({"bar": 1}) == 1
+
+
+@pytest.mark.asyncio
+async def test_using_router() -> None:
+    """Test using a router."""
+    app = FastAPI()
+
+    # Make sure that we can add routers
+    # to an API router
+    router = APIRouter()
+
+    add_routes(
+        router,
+        RunnableLambda(lambda foo: "hello"),
+        path="/chat",
+    )
+
+    app.include_router(router)


### PR DESCRIPTION
-- Disables the startup logs and the check for re-used paths for API routers.
-- API Router is unhashable, so we'll disable some non-essential features for API routers
