### PR TITLE
Add Feedback Endpoint to LangServe

### DIFF
--- a/langserve/schema.py
+++ b/langserve/schema.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List, Optional, Union
 
 try:
     from pydantic.v1 import BaseModel
@@ -59,3 +59,54 @@ class BatchResponseMetadata(SharedResponseMetadata):
     # Represents each parent run id for a given request, in
     # the same order in which they were received
     run_ids: List[str]
+
+
+class FeedbackCreateRequest(BaseModel):
+    """
+    Represents feedback given on an individual run
+    """
+
+    # TODO: move to uuid once we support serialization of uuids
+    run_id: str
+    """The associated run ID this feedback is logged for."""
+
+    key: str
+    """The metric name, tag, or aspect to provide feedback on."""
+
+    score: Optional[Union[float, int, bool]] = None
+    """Value or score to assign the run."""
+
+    value: Optional[Union[float, int, bool, str, Dict]] = None
+    """The display value for the feedback if not a metric."""
+
+    comment: Optional[str] = None
+    """Comment or explanation for the feedback."""
+
+
+class Feedback(BaseModel):
+    # TODO: move to datetime.datetime once we support serialization of datetimes
+    created_at: str
+    """The time the feedback was created."""
+
+    # TODO: move to datetime.datetime once we support serialization of datetimes
+    modified_at: str
+    """The time the feedback was last modified."""
+
+    # TODO: move to uuid once we support serialization of uuids
+    run_id: str
+    """The associated run ID this feedback is logged for."""
+
+    key: str
+    """The metric name, tag, or aspect to provide feedback on."""
+
+    score: Optional[Union[float, int, bool]] = None
+    """Value or score to assign the run."""
+
+    value: Optional[Union[float, int, bool, str, Dict]] = None
+    """The display value for the feedback if not a metric."""
+
+    comment: Optional[str] = None
+    """Comment or explanation for the feedback."""
+
+    correction: Optional[Dict] = None
+    """Correction for the run."""

--- a/langserve/schema.py
+++ b/langserve/schema.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from typing import Dict, List, Optional, Union
+from uuid import UUID
 
 try:
     from pydantic.v1 import BaseModel
@@ -47,7 +49,7 @@ class SingletonResponseMetadata(SharedResponseMetadata):
     """
 
     # Represents the parent run id for a given request
-    run_id: str
+    run_id: UUID
 
 
 class BatchResponseMetadata(SharedResponseMetadata):
@@ -58,55 +60,48 @@ class BatchResponseMetadata(SharedResponseMetadata):
 
     # Represents each parent run id for a given request, in
     # the same order in which they were received
-    run_ids: List[str]
+    run_ids: List[UUID]
 
 
-class FeedbackCreateRequest(BaseModel):
+class BaseFeedback(BaseModel):
+    """
+    Shared information between create requests of feedback and feedback objects
+    """
+
+    run_id: UUID
+    """The associated run ID this feedback is logged for."""
+
+    key: str
+    """The metric name, tag, or aspect to provide feedback on."""
+
+    score: Optional[Union[float, int, bool]] = None
+    """Value or score to assign the run."""
+
+    value: Optional[Union[float, int, bool, str, Dict]] = None
+    """The display value for the feedback if not a metric."""
+
+    comment: Optional[str] = None
+    """Comment or explanation for the feedback."""
+
+
+class FeedbackCreateRequest(BaseFeedback):
+    """
+    Represents a request that creates feedback for an individual run
+    """
+
+    pass
+
+
+class Feedback(BaseFeedback):
     """
     Represents feedback given on an individual run
     """
 
-    # TODO: move to uuid once we support serialization of uuids
-    run_id: str
-    """The associated run ID this feedback is logged for."""
-
-    key: str
-    """The metric name, tag, or aspect to provide feedback on."""
-
-    score: Optional[Union[float, int, bool]] = None
-    """Value or score to assign the run."""
-
-    value: Optional[Union[float, int, bool, str, Dict]] = None
-    """The display value for the feedback if not a metric."""
-
-    comment: Optional[str] = None
-    """Comment or explanation for the feedback."""
-
-
-class Feedback(BaseModel):
-    # TODO: move to datetime.datetime once we support serialization of datetimes
-    created_at: str
+    created_at: datetime
     """The time the feedback was created."""
 
-    # TODO: move to datetime.datetime once we support serialization of datetimes
-    modified_at: str
+    modified_at: datetime
     """The time the feedback was last modified."""
-
-    # TODO: move to uuid once we support serialization of uuids
-    run_id: str
-    """The associated run ID this feedback is logged for."""
-
-    key: str
-    """The metric name, tag, or aspect to provide feedback on."""
-
-    score: Optional[Union[float, int, bool]] = None
-    """Value or score to assign the run."""
-
-    value: Optional[Union[float, int, bool, str, Dict]] = None
-    """The display value for the feedback if not a metric."""
-
-    comment: Optional[str] = None
-    """Comment or explanation for the feedback."""
 
     correction: Optional[Dict] = None
     """Correction for the run."""

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -896,6 +896,9 @@ def add_routes(
             score=feedback_create_req.score,
             value=feedback_create_req.value,
             comment=feedback_create_req.comment,
+            source_info={
+                "from_langserve": True,
+            },
         )
 
         # We purposefully select out fields from langsmith so that we don't

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -329,7 +329,7 @@ def add_routes(
     output_type: Union[Type, Literal["auto"], BaseModel] = "auto",
     config_keys: Sequence[str] = (),
     include_callback_events: bool = False,
-    enable_feedback_endpoint: bool = True,
+    enable_feedback_endpoint: bool = False,
 ) -> None:
     """Register the routes on the given FastAPI app or APIRouter.
 
@@ -365,7 +365,7 @@ def add_routes(
             including events that occurred on the server side.
             Be sure not to include any sensitive information in the callback events.
         enable_feedback_endpoint: Whether to enable an endpoint for logging feedback
-            to LangSmith. Enabled by default. If this flag is enabled but LangSmith
+            to LangSmith. Enabled by default. If this flag is disabled or LangSmith
             tracing is not enabled for the runnable, then 400 errors will be thrown
             when accessing the feedback endpoint
     """
@@ -883,45 +883,43 @@ def add_routes(
             file_path,
         )
 
-    if enable_feedback_endpoint:
+    @app.post(namespace + "/feedback")
+    async def feedback(feedback_create_req: FeedbackCreateRequest) -> Feedback:
+        """
+        Send feedback on an individual run to langsmith
+        """
 
-        @app.post(namespace + "/feedback")
-        async def feedback(feedback_create_req: FeedbackCreateRequest) -> Feedback:
-            """
-            Send feedback on an individual run to langsmith
-            """
-
-            if not tracing_is_enabled():
-                raise HTTPException(
-                    400,
-                    "The feedback endpoint is only accessible when LangSmith is "
-                    + "enabled on your LangServe server.",
-                )
-
-            feedback_from_langsmith = langsmith_client.create_feedback(
-                feedback_create_req.run_id,
-                feedback_create_req.key,
-                score=feedback_create_req.score,
-                value=feedback_create_req.value,
-                comment=feedback_create_req.comment,
-                source_info={
-                    "from_langserve": True,
-                },
+        if not tracing_is_enabled() or not enable_feedback_endpoint:
+            raise HTTPException(
+                400,
+                "The feedback endpoint is only accessible when LangSmith is "
+                + "enabled on your LangServe server.",
             )
 
-            # We purposefully select out fields from langsmith so that we don't
-            # fail validation if langsmith adds extra fields. We prefer this over
-            # using "Extra.allow" in pydantic since syntax changes between pydantic
-            # 1.x and 2.x for this functionality
-            return Feedback(
-                run_id=str(feedback_from_langsmith.run_id),
-                created_at=str(feedback_from_langsmith.created_at),
-                modified_at=str(feedback_from_langsmith.modified_at),
-                key=str(feedback_from_langsmith.key),
-                score=feedback_from_langsmith.score,
-                value=feedback_from_langsmith.value,
-                comment=feedback_from_langsmith.comment,
-            )
+        feedback_from_langsmith = langsmith_client.create_feedback(
+            feedback_create_req.run_id,
+            feedback_create_req.key,
+            score=feedback_create_req.score,
+            value=feedback_create_req.value,
+            comment=feedback_create_req.comment,
+            source_info={
+                "from_langserve": True,
+            },
+        )
+
+        # We purposefully select out fields from langsmith so that we don't
+        # fail validation if langsmith adds extra fields. We prefer this over
+        # using "Extra.allow" in pydantic since syntax changes between pydantic
+        # 1.x and 2.x for this functionality
+        return Feedback(
+            run_id=str(feedback_from_langsmith.run_id),
+            created_at=str(feedback_from_langsmith.created_at),
+            modified_at=str(feedback_from_langsmith.modified_at),
+            key=str(feedback_from_langsmith.key),
+            score=feedback_from_langsmith.score,
+            value=feedback_from_langsmith.value,
+            comment=feedback_from_langsmith.comment,
+        )
 
     #######################################
     # Documentation variants of end points.

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -363,9 +363,6 @@ def add_routes(
             If true, the client will be able to show trace information
             including events that occurred on the server side.
             Be sure not to include any sensitive information in the callback events.
-        langsmith_client: a constructed langsmith client that can be used to send
-            feedback and other data to langsmith if an integration is enabled. Used
-            for dependency injection testing.
     """
     try:
         from sse_starlette import EventSourceResponse

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -1,10 +1,13 @@
 """Test the server and client together."""
 import asyncio
+import datetime
 import json
+import os
 import uuid
 from asyncio import AbstractEventLoop
 from contextlib import asynccontextmanager, contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Union
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -19,6 +22,7 @@ from langchain.schema.messages import HumanMessage, SystemMessage
 from langchain.schema.runnable import Runnable, RunnableConfig, RunnablePassthrough
 from langchain.schema.runnable.base import RunnableLambda
 from langchain.schema.runnable.utils import ConfigurableField, Input, Output
+from langsmith import schemas as ls_schemas
 from pytest_mock import MockerFixture
 from typing_extensions import TypedDict
 
@@ -26,7 +30,7 @@ from langserve import server
 from langserve.callbacks import AsyncEventAggregatorCallback
 from langserve.client import RemoteRunnable
 from langserve.lzstring import LZString
-from langserve.schema import CustomUserType
+from langserve.schema import CustomUserType, Feedback
 from langserve.server import (
     _rename_pydantic_model,
     _replace_non_alphanumeric_with_underscores,
@@ -89,6 +93,7 @@ def app(event_loop: AbstractEventLoop) -> FastAPI:
         else:
             return x
 
+    os.environ["LANGCHAIN_TRACING_V2"] = "true"
     runnable_lambda = RunnableLambda(func=add_one_or_passthrough)
     app = FastAPI()
     try:
@@ -1467,3 +1472,69 @@ async def test_batch_returns_run_id(app: FastAPI) -> None:
         assert len(run_ids) == 2
         for run_id in run_ids:
             assert _is_valid_uuid(run_id)
+
+
+@pytest.mark.asyncio
+async def test_feedback_succeeds_when_langsmith_enabled() -> None:
+    """Test the server directly via HTTP requests."""
+
+    with patch("langserve.server.ls_client") as mocked_ls_client_package:
+        mocked_client = MagicMock(return_value=None)
+        mocked_ls_client_package.Client.return_value = mocked_client
+        print(mocked_client)
+        mocked_client.create_feedback.return_value = ls_schemas.Feedback(
+            id="5484c6b3-5a1a-4a87-b2c7-2e39e7a7e4ac",
+            created_at=datetime.datetime(1994, 9, 19, 9, 19),
+            modified_at=datetime.datetime(1994, 9, 19, 9, 19),
+            run_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            key="silliness",
+            score=1000,
+        )
+
+        local_app = FastAPI()
+        add_routes(
+            local_app,
+            RunnableLambda(lambda foo: "hello"),
+        )
+
+        async with get_async_test_client(
+            local_app, raise_app_exceptions=True
+        ) as async_client:
+            response = await async_client.post(
+                "/feedback",
+                json={
+                    "run_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                    "key": "silliness",
+                    "score": 1000,
+                },
+            )
+
+            deserialized_response = Feedback.parse_obj(response.json())
+            expected_deserialized_response = Feedback(
+                run_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                key="silliness",
+                score=1000,
+                created_at=str(datetime.datetime(1994, 9, 19, 9, 19)),
+                modified_at=str(datetime.datetime(1994, 9, 19, 9, 19)),
+            )
+
+            assert deserialized_response == expected_deserialized_response
+
+
+@pytest.mark.asyncio
+async def test_feedback_fails_when_langsmith_disabled(app: FastAPI) -> None:
+    """Test the server directly via HTTP requests."""
+    default_env = os.environ
+    os.environ["LANGCHAIN_TRACING_V2"] = "false"
+    async with get_async_test_client(app, raise_app_exceptions=True) as async_client:
+        response = await async_client.post(
+            "/feedback",
+            json={
+                "run_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                "key": "silliness",
+                "score": 1000,
+            },
+        )
+        assert response.status_code == 400
+
+    os.environ = default_env


### PR DESCRIPTION
This PR adds an endpoint to LangServe servers called `/feedback` which will take in feedback in the same schema as LangSmith feedback, and forward along said feedback to LangSmith. If the server does not have LangSmith enabled, then the `/feedback` endpoint will return a 400. 