### PR TITLE
Allow dynamic modification of RunnableConfig based on request properties

### DIFF
--- a/examples/configurable_chain/client.ipynb
+++ b/examples/configurable_chain/client.ipynb
@@ -27,7 +27,7 @@
     "import requests\n",
     "\n",
     "inputs = {\"input\": {\"topic\": \"sports\"}}\n",
-    "response = requests.post(\"http://localhost:8000/config_from_rc/invoke\", json=inputs)\n",
+    "response = requests.post(\"http://localhost:8000/configurable_temp/invoke\", json=inputs)\n",
     "\n",
     "response.json()"
    ]
@@ -49,7 +49,7 @@
    "source": [
     "from langserve import RemoteRunnable\n",
     "\n",
-    "remote_runnable = RemoteRunnable(\"http://localhost:8000/config_from_rc\")"
+    "remote_runnable = RemoteRunnable(\"http://localhost:8000/configurable_temp\")"
    ]
   },
   {

--- a/examples/configurable_chain/client.ipynb
+++ b/examples/configurable_chain/client.ipynb
@@ -18,28 +18,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'output': \"Why don't scientists trust atoms who play sports?\\n\\nBecause they make up everything!\",\n",
-       " 'callback_events': []}"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import requests\n",
     "\n",
     "inputs = {\"input\": {\"topic\": \"sports\"}}\n",
-    "response = requests.post(\"http://localhost:8000/invoke\", json=inputs)\n",
+    "response = requests.post(\"http://localhost:8000/config_from_rc/invoke\", json=inputs)\n",
     "\n",
     "response.json()"
    ]
@@ -61,7 +49,7 @@
    "source": [
     "from langserve import RemoteRunnable\n",
     "\n",
-    "remote_runnable = RemoteRunnable(\"http://localhost:8000/\")"
+    "remote_runnable = RemoteRunnable(\"http://localhost:8000/config_from_rc\")"
    ]
   },
   {
@@ -177,6 +165,104 @@
     "    },\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configurability Based on Request Properties\n",
+    "\n",
+    "If you want to change your chain invocation based on your request's properties,\n",
+    "you can do so with `add_routes`'s `per_req_config_modifier` method as follows:\n",
+    "\n",
+    "```python \n",
+    "\n",
+    "# Add another example route where you can configure the model based\n",
+    "# on properties of the request. This is useful for passing in API\n",
+    "# keys from request headers (WITH CAUTION) or using other properties\n",
+    "# of the request to configure the model.\n",
+    "def fetch_api_key_from_header(config: Dict[str, Any], req: Request) -> Dict[str, Any]:\n",
+    "    if \"x-api-key\" in req.headers:\n",
+    "        config[\"configurable\"][\"openai_api_key\"] = req.headers[\"x-api-key\"]\n",
+    "    return config\n",
+    "\n",
+    "dynamic_auth_model = ChatOpenAI(openai_api_key='placeholder').configurable_fields(\n",
+    "    openai_api_key=ConfigurableField(\n",
+    "        id=\"openai_api_key\",\n",
+    "        name=\"OpenAI API Key\",\n",
+    "        description=(\n",
+    "            \"API Key for OpenAI interactions\"\n",
+    "        ),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "dynamic_auth_chain = dynamic_auth_model | StrOutputParser()\n",
+    "\n",
+    "add_routes(\n",
+    "    app, \n",
+    "    dynamic_auth_chain, \n",
+    "    path=\"/auth_from_header\",\n",
+    "    config_keys=[\"configurable\"], \n",
+    "    per_req_config_modifier=fetch_api_key_from_header\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we can see that our request to the model will only work if we have a specific request\n",
+    "header set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The model will fail with an auth error\n",
+    "unauthenticated_response = requests.post(\n",
+    "    \"http://localhost:8000/auth_from_header/invoke\", json={\"input\": \"hello\"}\n",
+    ")\n",
+    "unauthenticated_response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, ensure that you have run the following locally on your shell\n",
+    "```bash\n",
+    "export TEST_API_KEY=<INSERT MY KEY HERE>\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The model will succeed as long as the above shell script is run previously\n",
+    "import os\n",
+    "\n",
+    "test_key = os.environ[\"TEST_API_KEY\"]\n",
+    "authenticated_response = requests.post(\n",
+    "    \"http://localhost:8000/auth_from_header/invoke\",\n",
+    "    json={\"input\": \"hello\"},\n",
+    "    headers={\"x-api-key\": test_key},\n",
+    ")\n",
+    "authenticated_response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -195,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/examples/configurable_chain/server.py
+++ b/examples/configurable_chain/server.py
@@ -61,7 +61,7 @@ chain = prompt | model | StrOutputParser()
 
 # Add routes requires you to specify which config keys are accepted
 # specifically, you must accept `configurable` as a config key.
-add_routes(app, chain, path="/config_from_rc", config_keys=["configurable"])
+add_routes(app, chain, path="/configurable_temp", config_keys=["configurable"])
 
 
 ###############################################################################

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -13,6 +13,7 @@ from inspect import isclass
 from typing import (
     Any,
     AsyncIterator,
+    Callable,
     Dict,
     Generator,
     Literal,
@@ -70,6 +71,10 @@ except ImportError:
     # [server] extra not installed
     APIRouter = FastAPI = Any
 
+# A function that that takes a config and a raw request
+# and updates the config based on the request.
+PerRequestConfigModifier = Callable[[Dict[str, Any], Request], Dict[str, Any]]
+
 
 def _config_from_hash(config_hash: str) -> Dict[str, Any]:
     try:
@@ -90,6 +95,8 @@ def _unpack_request_config(
     *configs: Union[BaseModel, Mapping, str],
     keys: Sequence[str],
     model: Type[BaseModel],
+    request: Request,
+    per_req_config_modifier: Optional[PerRequestConfigModifier],
 ) -> Dict[str, Any]:
     """Merge configs, and project the given keys from the merged dict."""
     config_dicts = []
@@ -103,7 +110,12 @@ def _unpack_request_config(
         else:
             raise TypeError(f"Expected a string, dict or BaseModel got {type(config)}")
     config = merge_configs(*config_dicts)
-    return {k: config[k] for k in keys if k in config}
+    projected_config = {k: config[k] for k in keys if k in config}
+    return (
+        per_req_config_modifier(projected_config, request)
+        if per_req_config_modifier
+        else projected_config
+    )
 
 
 def _unpack_input(validated_model: BaseModel) -> Any:
@@ -330,6 +342,7 @@ def add_routes(
     config_keys: Sequence[str] = (),
     include_callback_events: bool = False,
     enable_feedback_endpoint: bool = False,
+    per_req_config_modifier: Optional[PerRequestConfigModifier] = None,
 ) -> None:
     """Register the routes on the given FastAPI app or APIRouter.
 
@@ -368,6 +381,11 @@ def add_routes(
             to LangSmith. Enabled by default. If this flag is disabled or LangSmith
             tracing is not enabled for the runnable, then 400 errors will be thrown
             when accessing the feedback endpoint
+        per_req_config_modifier: optional function that can be used to update the
+            RunnableConfig for a given run based on the raw request. This is useful,
+            for example, if the user wants to pass in a header containing credentials
+            to a runnable. The RunnableConfig is presented in its dictionary form.
+            Note that only keys in `config_keys` will be modifiable by this function.
     """
     try:
         from sse_starlette import EventSourceResponse
@@ -487,6 +505,8 @@ def add_routes(
                 body.config,
                 keys=config_keys,
                 model=ConfigPayload,
+                request=request,
+                per_req_config_modifier=per_req_config_modifier,
             )
             # Unpack the input dynamically using the input schema of the runnable.
             # This takes into account changes in the input type when
@@ -570,7 +590,12 @@ def add_routes(
 
                 configs = [
                     _unpack_request_config(
-                        config_hash, config, keys=config_keys, model=ConfigPayload
+                        config_hash,
+                        config,
+                        keys=config_keys,
+                        model=ConfigPayload,
+                        request=request,
+                        per_req_config_modifier=per_req_config_modifier,
                     )
                     for config in config
                 ]
@@ -580,6 +605,8 @@ def add_routes(
                     config,
                     keys=config_keys,
                     model=ConfigPayload,
+                    request=request,
+                    per_req_config_modifier=per_req_config_modifier,
                 )
             else:
                 raise HTTPException(
@@ -819,11 +846,15 @@ def add_routes(
     @app.get(
         f"{namespace}/input_schema", tags=route_tags, name=_route_name("input_schema")
     )
-    async def input_schema(config_hash: str = "") -> Any:
+    async def input_schema(request: Request, config_hash: str = "") -> Any:
         """Return the input schema of the runnable."""
         with _with_validation_error_translation():
             config = _unpack_request_config(
-                config_hash, keys=config_keys, model=ConfigPayload
+                config_hash,
+                keys=config_keys,
+                model=ConfigPayload,
+                request=request,
+                per_req_config_modifier=per_req_config_modifier,
             )
 
         return runnable.get_input_schema(config).schema()
@@ -834,13 +865,19 @@ def add_routes(
         name=_route_name_with_config("output_schema"),
     )
     @app.get(
-        f"{namespace}/output_schema", tags=route_tags, name=_route_name("output_schema")
+        f"{namespace}/output_schema",
+        tags=route_tags,
+        name=_route_name("output_schema"),
     )
-    async def output_schema(config_hash: str = "") -> Any:
+    async def output_schema(request: Request, config_hash: str = "") -> Any:
         """Return the output schema of the runnable."""
         with _with_validation_error_translation():
             config = _unpack_request_config(
-                config_hash, keys=config_keys, model=ConfigPayload
+                config_hash,
+                keys=config_keys,
+                model=ConfigPayload,
+                request=request,
+                per_req_config_modifier=per_req_config_modifier,
             )
         return runnable.get_output_schema(config).schema()
 
@@ -852,11 +889,15 @@ def add_routes(
     @app.get(
         f"{namespace}/config_schema", tags=route_tags, name=_route_name("config_schema")
     )
-    async def config_schema(config_hash: str = "") -> Any:
+    async def config_schema(request: Request, config_hash: str = "") -> Any:
         """Return the config schema of the runnable."""
         with _with_validation_error_translation():
             config = _unpack_request_config(
-                config_hash, keys=config_keys, model=ConfigPayload
+                config_hash,
+                keys=config_keys,
+                model=ConfigPayload,
+                request=request,
+                per_req_config_modifier=per_req_config_modifier,
             )
         return runnable.with_config(config).config_schema(include=config_keys).schema()
 
@@ -865,11 +906,17 @@ def add_routes(
         include_in_schema=False,
     )
     @app.get(namespace + "/playground/{file_path:path}", include_in_schema=False)
-    async def playground(file_path: str, config_hash: str = "") -> Any:
+    async def playground(
+        file_path: str, request: Request, config_hash: str = ""
+    ) -> Any:
         """Return the playground of the runnable."""
         with _with_validation_error_translation():
             config = _unpack_request_config(
-                config_hash, keys=config_keys, model=ConfigPayload
+                config_hash,
+                keys=config_keys,
+                model=ConfigPayload,
+                request=request,
+                per_req_config_modifier=per_req_config_modifier,
             )
         return await serve_playground(
             runnable.with_config(config),

--- a/tests/unit_tests/test_validation.py
+++ b/tests/unit_tests/test_validation.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
+from unittest.mock import MagicMock
 
 import pytest
+from fastapi import Request
 from langchain.prompts import PromptTemplate
 from langchain.schema.runnable.utils import ConfigurableField
 
@@ -157,6 +159,8 @@ def test_invoke_request_with_runnables() -> None:
             ).config,
             keys=[],
             model=config,
+            request=MagicMock(Request),
+            per_req_config_modifier=lambda x, y: x,
         )
         == {}
     )
@@ -179,7 +183,11 @@ def test_invoke_request_with_runnables() -> None:
     }
 
     assert _unpack_request_config(
-        request.config, keys=["configurable"], model=config
+        request.config,
+        keys=["configurable"],
+        model=config,
+        request=MagicMock(Request),
+        per_req_config_modifier=lambda x, y: x,
     ) == {
         "configurable": {"template": "goodbye {name}"},
     }


### PR DESCRIPTION
Users may want to modify the properties of the RunnableConfig based on the incoming request. This is useful if the end user is serving, for example, an Azure OpenAI model, and they have a token in their request header.