### PR TITLE
Fix playground not loading issue by adding  encoding="utf-8"

### DIFF
--- a/langserve/playground.py
+++ b/langserve/playground.py
@@ -41,7 +41,7 @@ async def serve_playground(
         return Response("Not Found", status_code=404)
 
     try:
-        with open(local_file_path) as f:
+        with open(local_file_path, encoding="utf-8") as f:
             mime_type = mimetypes.guess_type(local_file_path)[0]
             if mime_type in ("text/html", "text/css", "application/javascript"):
                 response = PlaygroundTemplate(f.read()).substitute(


### PR DESCRIPTION
Since the js file in /playground/dist/assets might contain non-ASCII code, it is safer to specify the encoding when opening the file.

Otherwise, it might run into this error, which stops the playground from loading.


`UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 163499: character maps to <undefined>
`

**[This error happened on a Windows Machine]**