### PR TITLE
add metadata event to /stream for collecting run_id of individual runs

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -692,12 +692,14 @@ def add_routes(
                     if not has_sent_metadata and event_aggregator.callback_events:
                         yield {
                             "event": "metadata",
-                            "data": {
-                                "run_id": _get_base_run_id_as_str(event_aggregator),
-                            },
+                            "data": json.dumps(
+                                {
+                                    "run_id": _get_base_run_id_as_str(event_aggregator),
+                                }
+                            ),
                         }
                         has_sent_metadata = True
-                        
+
                     yield {
                         "data": well_known_lc_serializer.dumps(chunk),
                         "event": "data",

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -681,10 +681,23 @@ def add_routes(
                     ) from validation_exception
 
             try:
+                config_w_callbacks = config.copy()
+                event_aggregator = AsyncEventAggregatorCallback()
+                config_w_callbacks["callbacks"] = [event_aggregator]
+                has_sent_metadata = False
                 async for chunk in runnable.astream(
                     input_,
-                    config=config,
+                    config=config_w_callbacks,
                 ):
+                    if not has_sent_metadata and event_aggregator.callback_events:
+                        yield {
+                            "event": "metadata",
+                            "data": {
+                                "run_id": _get_base_run_id_as_str(event_aggregator),
+                            },
+                        }
+                        has_sent_metadata = True
+                        
                     yield {
                         "data": well_known_lc_serializer.dumps(chunk),
                         "event": "data",

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -70,20 +70,21 @@ def _decode_eventstream(text: str) -> List[Dict[str, Any]]:
 
     return events
 
+
 def _replace_run_id_in_stream_resp(streamed_resp: str) -> str:
     """
     Replace the run_id in the streamed response's metadata with a placeholder.
 
     Assumes run_id only appears once in the text. This is hacky :)
     """
-    metadata_expected_str = "event: metadata\r\ndata: {'run_id': '"
+    metadata_expected_str = "event: metadata\r\ndata: {\"run_id\": \""
     run_id_idx = streamed_resp.find(metadata_expected_str)
     assert run_id_idx != -1
 
     uuid_start_pos = run_id_idx + len(metadata_expected_str)
     uuid_len = 36
 
-    uuid = streamed_resp[uuid_start_pos: uuid_start_pos + uuid_len]
+    uuid = streamed_resp[uuid_start_pos : uuid_start_pos + uuid_len]
     return streamed_resp.replace(uuid, "<REPLACED>")
 
 
@@ -297,12 +298,11 @@ async def test_server_async(app: FastAPI) -> None:
             response.text
         )
         expected_response_with_run_id_replaced = (
-            "event: metadata\r\ndata: {'run_id': '<REPLACED>'}\r\n\r\n" +
-            "event: data\r\ndata: 2\r\n\r\nevent: end\r\n\r\n"
+            "event: metadata\r\ndata: {\"run_id\": \"<REPLACED>\"}\r\n\r\n"
+            + "event: data\r\ndata: 2\r\n\r\nevent: end\r\n\r\n"
         )
         assert (
-            response_text_with_run_id_replaced 
-            == expected_response_with_run_id_replaced
+            response_text_with_run_id_replaced == expected_response_with_run_id_replaced
         )
 
         response = await async_client.post("/stream_log", json={"input": 1})
@@ -416,7 +416,7 @@ async def test_server_bound_async(app_for_config: FastAPI) -> None:
     response_with_run_id_replaced = _replace_run_id_in_stream_resp(response.text)
     assert (
         response_with_run_id_replaced
-        == """event: metadata\r\ndata: {\'run_id\': \'<REPLACED>\'}\r\n\r\nevent: data\r\ndata: {"tags": ["another-one", "test"], "configurable": null}\r\n\r\nevent: end\r\n\r\n"""  # noqa: E501
+        == """event: metadata\r\ndata: {"run_id": "<REPLACED>"}\r\n\r\nevent: data\r\ndata: {"tags": ["another-one", "test"], "configurable": null}\r\n\r\nevent: end\r\n\r\n"""  # noqa: E501
     )
 
 

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -77,7 +77,7 @@ def _replace_run_id_in_stream_resp(streamed_resp: str) -> str:
 
     Assumes run_id only appears once in the text. This is hacky :)
     """
-    metadata_expected_str = "event: metadata\r\ndata: {\"run_id\": \""
+    metadata_expected_str = 'event: metadata\r\ndata: {"run_id": "'
     run_id_idx = streamed_resp.find(metadata_expected_str)
     assert run_id_idx != -1
 
@@ -298,7 +298,7 @@ async def test_server_async(app: FastAPI) -> None:
             response.text
         )
         expected_response_with_run_id_replaced = (
-            "event: metadata\r\ndata: {\"run_id\": \"<REPLACED>\"}\r\n\r\n"
+            'event: metadata\r\ndata: {"run_id": "<REPLACED>"}\r\n\r\n'
             + "event: data\r\ndata: 2\r\n\r\nevent: end\r\n\r\n"
         )
         assert (

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -70,6 +70,22 @@ def _decode_eventstream(text: str) -> List[Dict[str, Any]]:
 
     return events
 
+def _replace_run_id_in_stream_resp(streamed_resp: str) -> str:
+    """
+    Replace the run_id in the streamed response's metadata with a placeholder.
+
+    Assumes run_id only appears once in the text. This is hacky :)
+    """
+    metadata_expected_str = "event: metadata\r\ndata: {'run_id': '"
+    run_id_idx = streamed_resp.find(metadata_expected_str)
+    assert run_id_idx != -1
+
+    uuid_start_pos = run_id_idx + len(metadata_expected_str)
+    uuid_len = 36
+
+    uuid = streamed_resp[uuid_start_pos: uuid_start_pos + uuid_len]
+    return streamed_resp.replace(uuid, "<REPLACED>")
+
 
 @pytest.fixture(scope="session")
 def event_loop():
@@ -277,7 +293,17 @@ async def test_server_async(app: FastAPI) -> None:
 
         # Test stream
         response = await async_client.post("/stream", json={"input": 1})
-        assert response.text == "event: data\r\ndata: 2\r\n\r\nevent: end\r\n\r\n"
+        response_text_with_run_id_replaced = _replace_run_id_in_stream_resp(
+            response.text
+        )
+        expected_response_with_run_id_replaced = (
+            "event: metadata\r\ndata: {'run_id': '<REPLACED>'}\r\n\r\n" +
+            "event: data\r\ndata: 2\r\n\r\nevent: end\r\n\r\n"
+        )
+        assert (
+            response_text_with_run_id_replaced 
+            == expected_response_with_run_id_replaced
+        )
 
         response = await async_client.post("/stream_log", json={"input": 1})
         assert response.text.startswith("event: data\r\n")
@@ -386,9 +412,11 @@ async def test_server_bound_async(app_for_config: FastAPI) -> None:
         json={"input": 1, "config": {"tags": ["another-one"]}},
     )
     assert response.status_code == 200
+
+    response_with_run_id_replaced = _replace_run_id_in_stream_resp(response.text)
     assert (
-        response.text
-        == """event: data\r\ndata: {"tags": ["another-one", "test"], "configurable": null}\r\n\r\nevent: end\r\n\r\n"""  # noqa: E501
+        response_with_run_id_replaced
+        == """event: metadata\r\ndata: {\'run_id\': \'<REPLACED>\'}\r\n\r\nevent: data\r\ndata: {"tags": ["another-one", "test"], "configurable": null}\r\n\r\nevent: end\r\n\r\n"""  # noqa: E501
     )
 
 


### PR DESCRIPTION
Adds a new event with type `metadata` that can return metadata about a run. This can be used for getting a run_id from the `/stream` API

### Testing
- Unit Tests: added in `test_server_client`
- Manual Tests: I ran `examples/llm/server.py` locally and ensured the returned run_id from the metadata event matched the one logged to langsmith