### PR TITLE
enable eager mode for feedback from langserve

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -967,6 +967,7 @@ def add_routes(
             source_info={
                 "from_langserve": True,
             },
+            eager=True
         )
 
         # We purposefully select out fields from langsmith so that we don't

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -967,7 +967,7 @@ def add_routes(
             source_info={
                 "from_langserve": True,
             },
-            eager=True
+            eager=True,
         )
 
         # We purposefully select out fields from langsmith so that we don't

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -32,7 +32,7 @@ from langchain.load.serializable import Serializable
 from langchain.schema.runnable import Runnable, RunnableConfig
 from langchain.schema.runnable.config import get_config_list, merge_configs
 from langsmith import client as ls_client
-from langsmith.utils import tracing_is_enabled, LangSmithNotFoundError
+from langsmith.utils import LangSmithNotFoundError, tracing_is_enabled
 from typing_extensions import Annotated
 
 from langserve.callbacks import AsyncEventAggregatorCallback, CallbackEventDict
@@ -958,7 +958,7 @@ def add_routes(
                 + "enabled on your LangServe server.",
             )
 
-        try: 
+        try:
             feedback_from_langsmith = langsmith_client.create_feedback(
                 feedback_create_req.run_id,
                 feedback_create_req.key,
@@ -979,10 +979,7 @@ def add_routes(
                 stop_after_attempt=3,
             )
         except LangSmithNotFoundError:
-            raise HTTPException(
-                404,
-                "No run with the given run_id exists"
-            )
+            raise HTTPException(404, "No run with the given run_id exists")
 
         # We purposefully select out fields from langsmith so that we don't
         # fail validation if langsmith adds extra fields. We prefer this over

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -23,6 +23,7 @@ from langchain.schema.runnable import Runnable, RunnableConfig, RunnablePassthro
 from langchain.schema.runnable.base import RunnableLambda
 from langchain.schema.runnable.utils import ConfigurableField, Input, Output
 from langsmith import schemas as ls_schemas
+from langsmith.utils import LangSmithNotFoundError
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 from typing_extensions import TypedDict
@@ -1599,6 +1600,36 @@ async def test_feedback_succeeds_when_langsmith_enabled() -> None:
             }
 
             assert response.json() == expected_response_json
+
+
+@pytest.mark.asyncio
+async def test_feedback_fails_when_run_doesnt_exist() -> None:
+    """Tests that the feedback endpoint can't accept feedback for a non existent run."""
+
+    with patch("langserve.server.ls_client") as mocked_ls_client_package:
+        mocked_client = MagicMock(return_value=None)
+        mocked_ls_client_package.Client.return_value = mocked_client
+        mocked_client.create_feedback.side_effect = LangSmithNotFoundError("no run :/")
+        local_app = FastAPI()
+        add_routes(
+            local_app,
+            RunnableLambda(lambda foo: "hello"),
+            enable_feedback_endpoint=True,
+        )
+
+        async with get_async_test_client(
+            local_app, raise_app_exceptions=True
+        ) as async_client:
+            response = await async_client.post(
+                "/feedback",
+                json={
+                    "run_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                    "key": "silliness",
+                    "score": 1000,
+                },
+            )
+
+            assert response.status_code == 404
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
We want to ensure that langsmith feedback is only submitted for existing runs, as it makes the UI much easier to manage, as it knows that a successful `/feedback` request equates to successfully submitted feedback.

### Testing
I spun up a server and made sure I could submit feedback on an existing run:
<img width="988" alt="Screenshot 2023-11-07 at 11 22 37 AM" src="https://github.com/langchain-ai/langserve/assets/9028897/c0685fd7-1e97-463e-bf37-3dd341a104fd">


And that a non existing run retries 3 times then fails:
<img width="978" alt="Screenshot 2023-11-07 at 11 22 26 AM" src="https://github.com/langchain-ai/langserve/assets/9028897/c3de6869-3929-4527-a401-0db33c33cd14">


