### PR TITLE
Update examples to use pydantic v1 for safety

### DIFF
--- a/examples/agent/server.py
+++ b/examples/agent/server.py
@@ -9,7 +9,7 @@ from langchain.embeddings import OpenAIEmbeddings
 from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain.tools.render import format_tool_to_openai_function
 from langchain.vectorstores import FAISS
-from pydantic import BaseModel
+from langchain.pydantic_v1 import BaseModel
 
 from langserve import add_routes
 

--- a/examples/agent/server.py
+++ b/examples/agent/server.py
@@ -7,9 +7,9 @@ from langchain.agents.output_parsers import OpenAIFunctionsAgentOutputParser
 from langchain.chat_models import ChatOpenAI
 from langchain.embeddings import OpenAIEmbeddings
 from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.pydantic_v1 import BaseModel
 from langchain.tools.render import format_tool_to_openai_function
 from langchain.vectorstores import FAISS
-from langchain.pydantic_v1 import BaseModel
 
 from langserve import add_routes
 

--- a/examples/conversational_retrieval_chain/server.py
+++ b/examples/conversational_retrieval_chain/server.py
@@ -6,8 +6,8 @@ from fastapi import FastAPI
 from langchain.chains import ConversationalRetrievalChain
 from langchain.chat_models import ChatOpenAI
 from langchain.embeddings import OpenAIEmbeddings
-from langchain.vectorstores import FAISS
 from langchain.pydantic_v1 import BaseModel, Field
+from langchain.vectorstores import FAISS
 
 from langserve import add_routes
 

--- a/examples/conversational_retrieval_chain/server.py
+++ b/examples/conversational_retrieval_chain/server.py
@@ -7,7 +7,7 @@ from langchain.chains import ConversationalRetrievalChain
 from langchain.chat_models import ChatOpenAI
 from langchain.embeddings import OpenAIEmbeddings
 from langchain.vectorstores import FAISS
-from pydantic import BaseModel, Field
+from langchain.pydantic_v1 import BaseModel, Field
 
 from langserve import add_routes
 

--- a/examples/file_processing/server.py
+++ b/examples/file_processing/server.py
@@ -17,8 +17,8 @@ import base64
 from fastapi import FastAPI
 from langchain.document_loaders.blob_loaders import Blob
 from langchain.document_loaders.parsers.pdf import PDFMinerParser
-from langchain.schema.runnable import RunnableLambda
 from langchain.pydantic_v1 import Field
+from langchain.schema.runnable import RunnableLambda
 
 from langserve import CustomUserType, add_routes
 

--- a/examples/file_processing/server.py
+++ b/examples/file_processing/server.py
@@ -18,7 +18,7 @@ from fastapi import FastAPI
 from langchain.document_loaders.blob_loaders import Blob
 from langchain.document_loaders.parsers.pdf import PDFMinerParser
 from langchain.schema.runnable import RunnableLambda
-from pydantic import Field
+from langchain.pydantic_v1 import Field
 
 from langserve import CustomUserType, add_routes
 

--- a/examples/widgets/server.py
+++ b/examples/widgets/server.py
@@ -14,7 +14,7 @@ from langchain.schema.messages import (
     FunctionMessage,
 )
 from langchain.schema.runnable import RunnableLambda
-from pydantic import BaseModel, Field
+from langchain.pydantic_v1 import BaseModel, Field
 
 from langserve.server import add_routes
 

--- a/examples/widgets/server.py
+++ b/examples/widgets/server.py
@@ -8,13 +8,13 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from langchain.document_loaders.blob_loaders import Blob
 from langchain.document_loaders.parsers.pdf import PDFMinerParser
+from langchain.pydantic_v1 import BaseModel, Field
 from langchain.schema.messages import (
     AIMessage,
     BaseMessage,
     FunctionMessage,
 )
 from langchain.schema.runnable import RunnableLambda
-from langchain.pydantic_v1 import BaseModel, Field
 
 from langserve.server import add_routes
 


### PR DESCRIPTION
This PR updates all exmaples to use langchain pydantic v1 namespace when using pydantic. 

The reason is that most of langchain objects are still using on pydantic v1 and
code should not mix v1 and v2.
