### PR TITLE
Bump timeout to 5 seconds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,5 @@ build-backend = "poetry.core.masonry.api"
 #                       section of the configuration file raise errors.
 addopts = "--strict-markers --strict-config --durations=5 -vv"
 # Global timeout for all tests. There shuold be a good reason for a test to
-# take more than 1 second
-timeout = 1
+# take more than 5 second
+timeout = 5


### PR DESCRIPTION
Bumping timeout to 5 seconds -- hopefully it'll identify the same test as the culprit