### PR TITLE
Change relative link to absolute links to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Get your LangServe instance started quickly with
 
 For more examples, see the templates 
 [index](https://github.com/langchain-ai/langchain/blob/master/templates/docs/INDEX.md) 
-or the [examples](./examples) directory.
+or the [examples](https://github.com/langchain-ai/langserve/tree/main/examples) directory.
 
 ### Server
 


### PR DESCRIPTION
Use absolute so it works when shown on langchain docs