### PR TITLE
add default configs for all served runnables

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -653,7 +653,7 @@ def add_routes(
     BatchResponse = create_batch_response_model(model_namespace, output_type_)
 
     async def _get_config_and_input(
-        request: Request, config_hash: str, endpoint: Optional[str] = None
+        request: Request, config_hash: str, *, endpoint: Optional[str] = None
     ) -> Tuple[RunnableConfig, Any]:
         """Extract the config and input from the request, validating the request."""
         try:

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -882,7 +882,7 @@ async def test_input_validation(
         server_runnable2,
         input_type=int,
         path="/add_one_config",
-        config_keys=["tags", "run_name", "metadata"],
+        config_keys=["tags", "metadata"],
     )
 
     async with get_async_remote_runnable(
@@ -911,6 +911,8 @@ async def test_input_validation(
         assert "metadata" in config_seen
         assert "__useragent" in config_seen["metadata"]
         assert "__langserve_version" in config_seen["metadata"]
+        assert "__langserve_endpoint" in config_seen["metadata"]
+        assert config_seen["metadata"]["__langserve_endpoint"] == "invoke"
 
     server_runnable2_spy = mocker.spy(server_runnable2, "ainvoke")
     async with get_async_remote_runnable(app, path="/add_one_config") as runnable2:
@@ -923,6 +925,8 @@ async def test_input_validation(
         assert config_seen["metadata"]["a"] == 5
         assert "__useragent" in config_seen["metadata"]
         assert "__langserve_version" in config_seen["metadata"]
+        assert "__langserve_endpoint" in config_seen["metadata"]
+        assert config_seen["metadata"]["__langserve_endpoint"] == "invoke"
 
 
 async def test_input_validation_with_lc_types(event_loop: AbstractEventLoop) -> None:

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -909,6 +909,7 @@ async def test_input_validation(
         # will still be added
         config_seen = server_runnable_spy.call_args[0][1]
         assert "metadata" in config_seen
+        assert "a" not in config_seen["metadata"]
         assert "__useragent" in config_seen["metadata"]
         assert "__langserve_version" in config_seen["metadata"]
         assert "__langserve_endpoint" in config_seen["metadata"]


### PR DESCRIPTION
Configures the run name to be the path, and some information about the associated repo to be in the metadata of the traced run