### PR TITLE
remove eager mode on feedback

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -34,7 +34,7 @@ from langchain.load.serializable import Serializable
 from langchain.schema.runnable import Runnable, RunnableConfig
 from langchain.schema.runnable.config import get_config_list, merge_configs
 from langsmith import client as ls_client
-from langsmith.utils import LangSmithNotFoundError, tracing_is_enabled
+from langsmith.utils import tracing_is_enabled
 from typing_extensions import Annotated
 
 try:


### PR DESCRIPTION
Eager mode is not a preferred option for langsmith APIs. We thus change the `/feedback` to use the regular submission of feedback flow.