### PR TITLE
Enable configurable by default langserve side

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -97,7 +97,7 @@ def _config_from_hash(config_hash: str) -> Dict[str, Any]:
 
 def _unpack_request_config(
     *configs: Union[BaseModel, Mapping, str],
-    keys: Sequence[str],
+    config_keys: Sequence[str],
     model: Type[BaseModel],
     request: Request,
     per_req_config_modifier: Optional[PerRequestConfigModifier],
@@ -115,12 +115,14 @@ def _unpack_request_config(
             raise TypeError(f"Expected a string, dict or BaseModel got {type(config)}")
     config = merge_configs(*config_dicts)
     if "configurable" in config and config["configurable"]:
-        if "configurable" not in keys:
+        if "configurable" not in config_keys:
             raise HTTPException(
                 422,
-                "The config field `configurable` has been disallowed by the server.",
+                "The config field `configurable` has been disallowed by the server. "
+                "This can be modified server side by adding `configurable` to the list "
+                "of `config_keys` argument in `add_routes`",
             )
-    projected_config = {k: config[k] for k in keys if k in config}
+    projected_config = {k: config[k] for k in config_keys if k in config}
     return (
         per_req_config_modifier(projected_config, request)
         if per_req_config_modifier
@@ -576,7 +578,7 @@ def add_routes(
             config = _unpack_request_config(
                 config_hash,
                 body.config,
-                keys=config_keys,
+                config_keys=config_keys,
                 model=ConfigPayload,
                 request=request,
                 per_req_config_modifier=per_req_config_modifier,
@@ -661,7 +663,7 @@ def add_routes(
                     _unpack_request_config(
                         config_hash,
                         config,
-                        keys=config_keys,
+                        config_keys=config_keys,
                         model=ConfigPayload,
                         request=request,
                         per_req_config_modifier=per_req_config_modifier,
@@ -672,7 +674,7 @@ def add_routes(
                 configs = _unpack_request_config(
                     config_hash,
                     config,
-                    keys=config_keys,
+                    config_keys=config_keys,
                     model=ConfigPayload,
                     request=request,
                     per_req_config_modifier=per_req_config_modifier,
@@ -942,7 +944,7 @@ def add_routes(
         with _with_validation_error_translation():
             config = _unpack_request_config(
                 config_hash,
-                keys=config_keys,
+                config_keys=config_keys,
                 model=ConfigPayload,
                 request=request,
                 per_req_config_modifier=per_req_config_modifier,
@@ -965,7 +967,7 @@ def add_routes(
         with _with_validation_error_translation():
             config = _unpack_request_config(
                 config_hash,
-                keys=config_keys,
+                config_keys=config_keys,
                 model=ConfigPayload,
                 request=request,
                 per_req_config_modifier=per_req_config_modifier,
@@ -985,7 +987,7 @@ def add_routes(
         with _with_validation_error_translation():
             config = _unpack_request_config(
                 config_hash,
-                keys=config_keys,
+                config_keys=config_keys,
                 model=ConfigPayload,
                 request=request,
                 per_req_config_modifier=per_req_config_modifier,
@@ -1004,7 +1006,7 @@ def add_routes(
         with _with_validation_error_translation():
             config = _unpack_request_config(
                 config_hash,
-                keys=config_keys,
+                config_keys=config_keys,
                 model=ConfigPayload,
                 request=request,
                 per_req_config_modifier=per_req_config_modifier,

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -118,8 +118,7 @@ def _unpack_request_config(
         if "configurable" not in keys:
             raise HTTPException(
                 422,
-                "Server code has modified the default accepted config keys to "
-                "not accept `configurable`. ",
+                "The config field `configurable` has been disallowed by the server.",
             )
     projected_config = {k: config[k] for k in keys if k in config}
     return (

--- a/tests/unit_tests/test_validation.py
+++ b/tests/unit_tests/test_validation.py
@@ -157,7 +157,7 @@ def test_invoke_request_with_runnables() -> None:
             Model(
                 input={"name": "bob"},
             ).config,
-            keys=[],
+            config_keys=[],
             model=config,
             request=MagicMock(Request),
             per_req_config_modifier=lambda x, y: x,
@@ -184,7 +184,7 @@ def test_invoke_request_with_runnables() -> None:
 
     assert _unpack_request_config(
         request.config,
-        keys=["configurable"],
+        config_keys=["configurable"],
         model=config,
         request=MagicMock(Request),
         per_req_config_modifier=lambda x, y: x,


### PR DESCRIPTION
* Enable configurable key by default
* Should be safe to enable by default since the user is already marking the runnable as configurable (when they make it configurable)
* Raise an client side error if the client specifies a `configurable` key but the server does not accept it (will help in debugging)
