### PR TITLE
Add support for API route via prefix

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -1029,7 +1029,7 @@ def add_routes(
             runnable.with_config(config),
             runnable.with_config(config).input_schema,
             config_keys,
-            f"{namespace}/playground",
+            f"{namespace}/playground" if isinstance(app, FastAPI) else f"{app.prefix}{namespace}/playground",
             file_path,
         )
 

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -1025,11 +1025,17 @@ def add_routes(
                 request=request,
                 per_req_config_modifier=per_req_config_modifier,
             )
+
+        if isinstance(app, FastAPI):  # type: ignore
+            base_url = f"{namespace}/playground"
+        else:
+            base_url = f"{app.prefix}{namespace}/playground"
+
         return await serve_playground(
             runnable.with_config(config),
             runnable.with_config(config).input_schema,
             config_keys,
-            f"{namespace}/playground" if isinstance(app, FastAPI) else f"{app.prefix}{namespace}/playground",
+            base_url,
             file_path,
         )
 

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -270,7 +270,7 @@ def test_serve_playground(app: FastAPI) -> None:
 
 
 @pytest.mark.asyncio
-async def test_serve_playground() -> None:
+async def test_serve_playground_with_api_router() -> None:
     """Test serving playground from an api router with a prefix."""
     app = FastAPI()
 

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -270,6 +270,27 @@ def test_serve_playground(app: FastAPI) -> None:
 
 
 @pytest.mark.asyncio
+async def test_serve_playground() -> None:
+    """Test serving playground from an api router with a prefix."""
+    app = FastAPI()
+
+    # Make sure that we can add routers
+    # to an API router
+    router = APIRouter(prefix="/langserve_runnables")
+
+    add_routes(
+        router,
+        RunnableLambda(lambda foo: "hello"),
+        path="/chat",
+    )
+
+    app.include_router(router)
+    async_client = AsyncClient(app=app, base_url="http://localhost:9999")
+    response = await async_client.get("/langserve_runnables/chat/playground/index.html")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_server_async(app: FastAPI) -> None:
     """Test the server directly via HTTP requests."""
     async with get_async_test_client(app, raise_app_exceptions=True) as async_client:


### PR DESCRIPTION
* Fix serving of playground assets when using an API router with a custom prefix
