### PR TITLE
Fix python docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ These endpoints match the [LangChain Expression Language interface](https://pyth
 You can find a playground page for your runnable at `/my_runnable/playground`. This exposes a simple UI to [configure](https://python.langchain.com/docs/expression_language/how_to/configure) and invoke your runnable with streaming output and intermediate steps.
 
 <p align="center">
-<img src="https://github.com/langchain-ai/langserve/assets/3205522/5ca56e29-f1bb-40f4-84b5-15916384a276" width="50%">
+<img src="https://github.com/langchain-ai/langserve/assets/3205522/5ca56e29-f1bb-40f4-84b5-15916384a276" width="50%"/>
 </p>
 
 ### Widgets
@@ -252,7 +252,7 @@ In addition, for configurable runnables, the playground will allow you to config
 ### Sharing
 
 <p align="center">
-<img src="https://github.com/langchain-ai/langserve/assets/3205522/86ce9c59-f8e4-4d08-9fa3-62030e0f521d" width="50%">
+<img src="https://github.com/langchain-ai/langserve/assets/3205522/86ce9c59-f8e4-4d08-9fa3-62030e0f521d" width="50%"/>
 </p>
 
 ## Legacy Chains
@@ -434,5 +434,5 @@ class FileProcessingRequest(CustomUserType):
 Example widget: 
 
 <p align="center">
-<img src="https://github.com/langchain-ai/langserve/assets/3205522/52199e46-9464-4c2e-8be8-222250e08c3f" width="50%">
+<img src="https://github.com/langchain-ai/langserve/assets/3205522/52199e46-9464-4c2e-8be8-222250e08c3f" width="50%"/>
 </p>


### PR DESCRIPTION
Docusaurus build doesn't like that the `img` tags don't have a closing tag. I think adding the `/>` to the end will fix it.