### PR TITLE
Enforce trailing slash in remote runnable

### DIFF
--- a/langserve/client.py
+++ b/langserve/client.py
@@ -235,7 +235,8 @@ class RemoteRunnable(Runnable[Input, Output]):
                 callback events returned by the server.
         """
         _client_kwargs = client_kwargs or {}
-        self.url = url
+        # Enforce trailing slash
+        self.url = url if url.endswith("/") else url + "/"
         self.sync_client = httpx.Client(
             base_url=url,
             timeout=timeout,
@@ -365,11 +366,6 @@ class RemoteRunnable(Runnable[Input, Output]):
 
         return outputs
 
-    def _enforce_trailing_slash(self, url: str) -> str:
-        if url.endswith("/"):
-            return url
-        return url + "/"
-
     def batch(
         self,
         inputs: List[Input],
@@ -465,7 +461,7 @@ class RemoteRunnable(Runnable[Input, Output]):
             "config": _without_callbacks(config),
             "kwargs": kwargs,
         }
-        endpoint = urljoin(self._enforce_trailing_slash(self.url), "stream")
+        endpoint = urljoin(self.url, "stream")
 
         try:
             from httpx_sse import connect_sse
@@ -551,7 +547,7 @@ class RemoteRunnable(Runnable[Input, Output]):
             "config": _without_callbacks(config),
             "kwargs": kwargs,
         }
-        endpoint = urljoin(self._enforce_trailing_slash(self.url), "stream")
+        endpoint = urljoin(self.url, "stream")
 
         try:
             from httpx_sse import aconnect_sse

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -1661,6 +1661,14 @@ async def test_feedback_fails_when_endpoint_disabled(app: FastAPI) -> None:
         assert response.status_code == 404
 
 
+async def test_enforce_trailing_slash_in_client() -> None:
+    """Ensure that the client enforces a trailing slash in the URL."""
+    r = RemoteRunnable(url="nosuchurl")
+    assert r.url == "nosuchurl/"
+    r = RemoteRunnable(url="nosuchurl/")
+    assert r.url == "nosuchurl/"
+
+
 async def test_per_request_config_modifier(
     event_loop: AbstractEventLoop, mocker: MockerFixture
 ) -> None:


### PR DESCRIPTION
Enforce trailing slash in URL.
