### PR TITLE
Example: Chat with history persisted on backend

### DIFF
--- a/examples/chat_with_persistence/client.ipynb
+++ b/examples/chat_with_persistence/client.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chat History\n",
+    "\n",
+    "Here we'll be interacting with a server that's exposing a chat bot with message history being persisted on the backend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import uuid\n",
+    "from langserve import RemoteRunnable\n",
+    "\n",
+    "chat = RemoteRunnable(\"http://localhost:8000/\", cookies={\"session_id\": \"5\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create a prompt composed of a system message and a human message."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content=' I apologize, but I do not actually have a name. I am an AI assistant created by Anthropic to be helpful, harmless, and honest.')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chat.invoke({\"human_input\": \"my name is eugene. what is your name?\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content=' Yes, you told me your name is Eugene.')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chat.invoke({\"human_input\": \"do you remember my name?\"})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/chat_with_persistence/client.ipynb
+++ b/examples/chat_with_persistence/client.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {
     "tags": []
    },
@@ -21,7 +21,7 @@
     "from langserve import RemoteRunnable\n",
     "\n",
     "conversation_id = str(uuid.uuid4())\n",
-    "chat = RemoteRunnable(\"http://localhost:8000/\", cookies={\"user_id\": \"eugene\", \"conversation_id\": conversation_id})"
+    "chat = RemoteRunnable(\"http://localhost:8000/\", cookies={\"user_id\": \"eugene\"})"
    ]
   },
   {
@@ -33,64 +33,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AIMessage(content=\" I don't actually have a name. I'm Claude, an AI assistant created by Anthropic.\")"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "chat.invoke({\"human_input\": \"my name is eugene. what is your name?\"})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AIMessage(content=' You said your name is Eugene.')"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "chat.invoke({\"human_input\": \"what was my name?\"})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Use different user but same conversation id"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 4,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content=' Hello Eugene! My name is Claude.')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "chat = RemoteRunnable(\"http://localhost:8000/\", cookies={\"user_id\": \"nuno\", \"conversation_id\": conversation_id})"
+    "chat.invoke({\"human_input\": \"my name is eugene. what is your name?\"}, {'configurable': { 'conversation_id': conversation_id } })"
    ]
   },
   {
@@ -103,7 +63,7 @@
     {
      "data": {
       "text/plain": [
-       "AIMessage(content=\" I'm afraid I don't actually know your name. Earlier I had said your name was Bob since I was asked to pretend you were an assistant named Bob. I'm an AI assistant created by Anthropic to be helpful, harmless, and honest. I don't have any information about your actual name.\")"
+       "AIMessage(content=' You said your name is Eugene.')"
       ]
      },
      "execution_count": 5,
@@ -112,12 +72,52 @@
     }
    ],
    "source": [
-    "chat.invoke({\"human_input\": \"what was my name?\"})"
+    "chat.invoke({\"human_input\": \"what was my name?\"}, {'configurable': { 'conversation_id': conversation_id } })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use different user but same conversation id"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "chat = RemoteRunnable(\"http://localhost:8000/\", cookies={\"user_id\": \"nuno\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content=\" I'm afraid I don't actually know your name. Earlier I had randomly suggested you could imagine yourself being an assistant named Bob, but that was just for the sake of an example. I don't have any information about your actual name or identity.\")"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chat.invoke({\"human_input\": \"what was my name?\"}, {'configurable': { 'conversation_id': conversation_id }})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {
     "tags": []
    },
@@ -141,36 +141,36 @@
       "\n",
       "\n",
       "1\n",
-      ",\n",
-      " 2\n",
-      ",\n",
-      " 3\n",
-      ",\n",
-      " 4\n",
-      ",\n",
-      " 5\n",
-      ",\n",
-      " 6\n",
-      ",\n",
-      " 7\n",
-      ",\n",
-      " 8\n",
-      ",\n",
-      " 9\n",
-      ",\n",
-      " 10\n"
+      "\n",
+      "2\n",
+      "\n",
+      "3\n",
+      "\n",
+      "4\n",
+      "\n",
+      "5\n",
+      "\n",
+      "6\n",
+      "\n",
+      "7\n",
+      "\n",
+      "8\n",
+      "\n",
+      "9\n",
+      "\n",
+      "10\n"
      ]
     }
    ],
    "source": [
-    "for chunk in chat.stream({'human_input': \"Can you count till 10?\"}):\n",
+    "for chunk in chat.stream({'human_input': \"Can you count till 10?\"},  {'configurable': { 'conversation_id': conversation_id } }):\n",
     "    print()\n",
     "    print(chunk.content, end='', flush=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -181,9 +181,9 @@
      "text": [
       "\u001b[01;34mchat_histories/\u001b[0m\n",
       "├── \u001b[01;34meugene\u001b[0m\n",
-      "│   └── 101630b7-213c-4387-a15d-4853140b05a3.json\n",
+      "│   └── ebd5f04f-6307-455a-b371-ecbae88ef8a9.json\n",
       "└── \u001b[01;34mnuno\u001b[0m\n",
-      "    └── 101630b7-213c-4387-a15d-4853140b05a3.json\n",
+      "    └── ebd5f04f-6307-455a-b371-ecbae88ef8a9.json\n",
       "\n",
       "2 directories, 2 files\n"
      ]
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {
     "tags": []
    },
@@ -217,7 +217,7 @@
       "  \u001b[1;39m{\n",
       "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
       "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
-      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" I don't actually have a name. I'm Claude, an AI assistant created by Anthropic.\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" Hello Eugene! My name is Claude.\"\u001b[0m\u001b[1;39m,\n",
       "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
       "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
       "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
@@ -246,12 +246,12 @@
     }
    ],
    "source": [
-    "!cat chat_histories/eugene/101630b7-213c-4387-a15d-4853140b05a3.json | jq ."
+    "!cat chat_histories/eugene/ebd5f04f-6307-455a-b371-ecbae88ef8a9.json | jq ."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
@@ -273,7 +273,7 @@
       "  \u001b[1;39m{\n",
       "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
       "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
-      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" I'm afraid I don't actually know your name. Earlier I had said your name was Bob since I was asked to pretend you were an assistant named Bob. I'm an AI assistant created by Anthropic to be helpful, harmless, and honest. I don't have any information about your actual name.\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" I'm afraid I don't actually know your name. Earlier I had randomly suggested you could imagine yourself being an assistant named Bob, but that was just for the sake of an example. I don't have any information about your actual name or identity.\"\u001b[0m\u001b[1;39m,\n",
       "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
       "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
       "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
@@ -291,7 +291,7 @@
       "  \u001b[1;39m{\n",
       "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"AIMessageChunk\"\u001b[0m\u001b[1;39m,\n",
       "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
-      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" Sure, I'd be happy to count to 10:\\n\\n1, 2, 3, 4, 5, 6, 7, 8, 9, 10\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" Sure, I'd be happy to count to 10:\\n\\n1\\n2\\n3\\n4\\n5\\n6\\n7\\n8\\n9\\n10\"\u001b[0m\u001b[1;39m,\n",
       "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
       "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"AIMessageChunk\"\u001b[0m\u001b[1;39m,\n",
       "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
@@ -302,7 +302,7 @@
     }
    ],
    "source": [
-    "!cat chat_histories/nuno/101630b7-213c-4387-a15d-4853140b05a3.json | jq ."
+    "!cat chat_histories/nuno/ebd5f04f-6307-455a-b371-ecbae88ef8a9.json | jq ."
    ]
   }
  ],

--- a/examples/chat_with_persistence/client.ipynb
+++ b/examples/chat_with_persistence/client.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -20,7 +20,8 @@
     "import uuid\n",
     "from langserve import RemoteRunnable\n",
     "\n",
-    "chat = RemoteRunnable(\"http://localhost:8000/\", cookies={\"session_id\": \"5\"})"
+    "conversation_id = str(uuid.uuid4())\n",
+    "chat = RemoteRunnable(\"http://localhost:8000/\", cookies={\"user_id\": \"eugene\", \"conversation_id\": conversation_id})"
    ]
   },
   {
@@ -32,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {
     "tags": []
    },
@@ -40,10 +41,10 @@
     {
      "data": {
       "text/plain": [
-       "AIMessage(content=' I apologize, but I do not actually have a name. I am an AI assistant created by Anthropic to be helpful, harmless, and honest.')"
+       "AIMessage(content=\" I don't actually have a name. I'm Claude, an AI assistant created by Anthropic.\")"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -62,7 +63,7 @@
     {
      "data": {
       "text/plain": [
-       "AIMessage(content=' Yes, you told me your name is Eugene.')"
+       "AIMessage(content=' You said your name is Eugene.')"
       ]
      },
      "execution_count": 3,
@@ -71,7 +72,237 @@
     }
    ],
    "source": [
-    "chat.invoke({\"human_input\": \"do you remember my name?\"})"
+    "chat.invoke({\"human_input\": \"what was my name?\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use different user but same conversation id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "chat = RemoteRunnable(\"http://localhost:8000/\", cookies={\"user_id\": \"nuno\", \"conversation_id\": conversation_id})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content=\" I'm afraid I don't actually know your name. Earlier I had said your name was Bob since I was asked to pretend you were an assistant named Bob. I'm an AI assistant created by Anthropic to be helpful, harmless, and honest. I don't have any information about your actual name.\")"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chat.invoke({\"human_input\": \"what was my name?\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " Sure\n",
+      ",\n",
+      " I\n",
+      "'d\n",
+      " be\n",
+      " happy\n",
+      " to\n",
+      " count\n",
+      " to\n",
+      " 10\n",
+      ":\n",
+      "\n",
+      "\n",
+      "1\n",
+      ",\n",
+      " 2\n",
+      ",\n",
+      " 3\n",
+      ",\n",
+      " 4\n",
+      ",\n",
+      " 5\n",
+      ",\n",
+      " 6\n",
+      ",\n",
+      " 7\n",
+      ",\n",
+      " 8\n",
+      ",\n",
+      " 9\n",
+      ",\n",
+      " 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "for chunk in chat.stream({'human_input': \"Can you count till 10?\"}):\n",
+    "    print()\n",
+    "    print(chunk.content, end='', flush=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[01;34mchat_histories/\u001b[0m\n",
+      "├── \u001b[01;34meugene\u001b[0m\n",
+      "│   └── 101630b7-213c-4387-a15d-4853140b05a3.json\n",
+      "└── \u001b[01;34mnuno\u001b[0m\n",
+      "    └── 101630b7-213c-4387-a15d-4853140b05a3.json\n",
+      "\n",
+      "2 directories, 2 files\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tree chat_histories/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1;39m[\n",
+      "  \u001b[1;39m{\n",
+      "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"human\"\u001b[0m\u001b[1;39m,\n",
+      "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"my name is eugene. what is your name?\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"human\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
+      "    \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "  \u001b[1;39m}\u001b[0m\u001b[1;39m,\n",
+      "  \u001b[1;39m{\n",
+      "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
+      "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" I don't actually have a name. I'm Claude, an AI assistant created by Anthropic.\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
+      "    \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "  \u001b[1;39m}\u001b[0m\u001b[1;39m,\n",
+      "  \u001b[1;39m{\n",
+      "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"human\"\u001b[0m\u001b[1;39m,\n",
+      "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"what was my name?\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"human\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
+      "    \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "  \u001b[1;39m}\u001b[0m\u001b[1;39m,\n",
+      "  \u001b[1;39m{\n",
+      "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
+      "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" You said your name is Eugene.\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
+      "    \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "  \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "\u001b[1;39m]\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat chat_histories/eugene/101630b7-213c-4387-a15d-4853140b05a3.json | jq ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1;39m[\n",
+      "  \u001b[1;39m{\n",
+      "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"human\"\u001b[0m\u001b[1;39m,\n",
+      "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"what was my name?\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"human\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
+      "    \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "  \u001b[1;39m}\u001b[0m\u001b[1;39m,\n",
+      "  \u001b[1;39m{\n",
+      "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
+      "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" I'm afraid I don't actually know your name. Earlier I had said your name was Bob since I was asked to pretend you were an assistant named Bob. I'm an AI assistant created by Anthropic to be helpful, harmless, and honest. I don't have any information about your actual name.\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"ai\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
+      "    \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "  \u001b[1;39m}\u001b[0m\u001b[1;39m,\n",
+      "  \u001b[1;39m{\n",
+      "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"human\"\u001b[0m\u001b[1;39m,\n",
+      "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"Can you count till 10?\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"human\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
+      "    \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "  \u001b[1;39m}\u001b[0m\u001b[1;39m,\n",
+      "  \u001b[1;39m{\n",
+      "    \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"AIMessageChunk\"\u001b[0m\u001b[1;39m,\n",
+      "    \u001b[0m\u001b[34;1m\"data\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{\n",
+      "      \u001b[0m\u001b[34;1m\"content\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\" Sure, I'd be happy to count to 10:\\n\\n1, 2, 3, 4, 5, 6, 7, 8, 9, 10\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"additional_kwargs\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[1;39m{}\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"AIMessageChunk\"\u001b[0m\u001b[1;39m,\n",
+      "      \u001b[0m\u001b[34;1m\"example\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;39mfalse\u001b[0m\u001b[1;39m\n",
+      "    \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "  \u001b[1;39m}\u001b[0m\u001b[1;39m\n",
+      "\u001b[1;39m]\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat chat_histories/nuno/101630b7-213c-4387-a15d-4853140b05a3.json | jq ."
    ]
   }
  ],

--- a/examples/chat_with_persistence/server.py
+++ b/examples/chat_with_persistence/server.py
@@ -24,11 +24,11 @@ from typing_extensions import TypedDict
 from langserve import add_routes
 
 
-def _is_valid_identifier(session_id: str) -> bool:
+def _is_valid_identifier(value: str) -> bool:
     """Check if the session ID is in a valid format."""
     # Use a regular expression to match the allowed characters
     valid_characters = re.compile(r"^[a-zA-Z0-9-_]+$")
-    return bool(valid_characters.match(session_id))
+    return bool(valid_characters.match(value))
 
 
 def create_session_factory(
@@ -92,17 +92,7 @@ def _per_request_config_modifier(
             detail="No session ID found. Please set a cookie named 'session_id'.",
         )
 
-    # Look for a cookie named "conversation_id"
-    conversation_id = request.cookies.get("conversation_id", None)
-
-    if conversation_id is not None and not isinstance(conversation_id, str):
-        raise HTTPException(
-            status_code=400,
-            detail="Conversation ID must be a string r",
-        )
-
     configurable["user_id"] = user_id
-    configurable["conversation_id"] = conversation_id
     config["configurable"] = configurable
     return config
 

--- a/examples/chat_with_persistence/server.py
+++ b/examples/chat_with_persistence/server.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""Example of a chat server with persistence handled on the backend.
+
+For simplicity, we're using file storage here -- to avoid the need to set up
+a database. This is obviously not a good idea for a production environment,
+but will help us to demonstrate the RunnableWithMessageHistory interface.
+
+We'll use cookies to identify the user. This will help illustrate how to
+fetch configuration from the request.
+"""
+import re
+from pathlib import Path
+from typing import Dict, Any
+from typing import Union, Callable
+
+from fastapi import FastAPI, Request, HTTPException
+from langchain.chat_models import ChatAnthropic
+from langchain.memory import FileChatMessageHistory
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from typing_extensions import TypedDict
+
+from langserve import add_routes
+
+
+def _is_valid_session_id(session_id: str) -> bool:
+    """Check if the session ID is in a valid format."""
+    # Use a regular expression to match the allowed characters
+    valid_characters = re.compile(r"^[a-zA-Z0-9-_]+$")
+    return bool(valid_characters.match(session_id))
+
+
+def create_session_factory(
+    base_dir: Union[str, Path]
+) -> Callable[[str], BaseChatMessageHistory]:
+    """Create a session ID factory that creates session IDs from a base dir.
+
+    Args:
+        base_dir: Base directory to use for storing the chat histories.
+
+    Returns:
+        A session ID factory that creates session IDs from a base path.
+    """
+    base_dir_ = Path(base_dir) if isinstance(base_dir, str) else base_dir
+    if not base_dir_.exists():
+        base_dir_.mkdir(parents=True)
+
+    def get_chat_history(session_id: str) -> FileChatMessageHistory:
+        """Get a chat history from a session ID."""
+        if not _is_valid_session_id(session_id):
+            raise ValueError(
+                f"Session ID {session_id} is not in a valid format. "
+                "Session ID must only contain alphanumeric characters, "
+                "hyphens, and underscores."
+            )
+
+        file_path = base_dir_ / f"{session_id}.json"
+        return FileChatMessageHistory(file_path)
+
+    return get_chat_history
+
+
+app = FastAPI(
+    title="LangChain Server",
+    version="1.0",
+    description="Spin up a simple api server using Langchain's Runnable interfaces",
+)
+
+
+def _per_request_config_modifier(
+    config: Dict[str, Any], request: Request
+) -> Dict[str, Any]:
+    """Update the config"""
+    config = config.copy()
+    configurable = config.get("configurable", {})
+    # Look for a cookie named "user_id"
+    user_id = request.cookies.get("user_id", None)
+    if user_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No session ID found. Please set a cookie named 'session_id'.",
+        )
+    configurable["user_id"] = user_id
+    config["configurable"] = configurable
+    return config
+
+
+# Declare a chain
+prompt = ChatPromptTemplate.from_messages(
+    [
+        ("system", "You're an assistant by the name of Bob."),
+        MessagesPlaceholder(variable_name="history"),
+        ("human", "{human_input}"),
+    ]
+)
+
+chain = prompt | ChatAnthropic(model="claude-2")
+
+
+class InputChat(TypedDict):
+    """Input for the chat endpoint."""
+
+    human_input: str
+    """Human input"""
+
+
+chain_with_history = RunnableWithMessageHistory(
+    chain,
+    create_session_factory("chat_histories"),
+    input_messages_key="human_input",
+    history_messages_key="history",
+).with_types(input_type=InputChat)
+
+
+add_routes(
+    app,
+    chain_with_history,
+    per_req_config_modifier=_per_request_config_modifier,
+    # Disable the playground for this example since there's no mechanism
+    # to set the cookie right now through the playground.
+    disabled_endpoints=["playground"],
+)
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="localhost", port=8000)

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -667,7 +667,6 @@ async def test_astream_log_diff_no_effect(
         "streamed_output": [2],
     }
 
-from langchain_core.vectorstores import VectorStore
 
 async def test_astream_log(async_remote_runnable: RemoteRunnable) -> None:
     """Test astream log."""

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -667,6 +667,7 @@ async def test_astream_log_diff_no_effect(
         "streamed_output": [2],
     }
 
+from langchain_core.vectorstores import VectorStore
 
 async def test_astream_log(async_remote_runnable: RemoteRunnable) -> None:
     """Test astream log."""


### PR DESCRIPTION
This PR shows a simple chat with history being persisted on the backend. It uses the file system to persist user chats.

The example is meant to illustrate how to use the interfaces, should not be used as is in production setting.
