### PR TITLE
Validate that endpoints are passed as a sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Enable: The code below will only enable `invoke`, `batch` and the corresponding 
 
 
 ```python
-add_routes(app, chain, enabled_endpoints=("invoke", "batch", "config_hashes"))
+add_routes(app, chain, enabled_endpoints=["invoke", "batch", "config_hashes"])
 ```
 
 Disable: The code below will disable the playground for the chain

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -149,6 +149,18 @@ class _EndpointConfiguration:
                 f"{disabled_endpoints}."
             )
 
+        if enabled_endpoints and not isinstance(enabled_endpoints, Sequence):
+            raise ValueError(
+                f"Expected enabled_endpoints to be a sequence (e.g., list or tuple), "
+                f"got {type(enabled_endpoints)}"
+            )
+
+        if disabled_endpoints and not isinstance(disabled_endpoints, Sequence):
+            raise ValueError(
+                f"Expected disabled_endpoints to be a sequence (e.g., list or tuple), "
+                f"got {type(disabled_endpoints)}"
+            )
+
         if enabled_endpoints is None:
             if disabled_endpoints is None:
                 is_invoke_enabled = True

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -1781,8 +1781,8 @@ async def test_uuid_serialization(event_loop: AbstractEventLoop) -> None:
         )
 
 
-async def test_all_endpoints_off() -> None:
-    """Test toggling endpoints."""
+async def test_endpoint_configurations() -> None:
+    """Test enabling/disabling endpoints."""
     app = FastAPI()
 
     # All endpoints disabled
@@ -1866,3 +1866,32 @@ async def test_all_endpoints_off() -> None:
                     method, "/config_off" + endpoint, json=payload
                 )
                 assert response.status_code != 404, f"endpoint {endpoint} should be on"
+
+    with pytest.raises(ValueError):
+        # Passing "invoke" instead of ["invoke"]
+        add_routes(
+            app,
+            RunnableLambda(lambda foo: "hello"),
+            disabled_endpoints="invoke",  # type: ignore
+            enable_feedback_endpoint=True,
+            path="/config_off",
+        )
+    with pytest.raises(ValueError):
+        # meow is not an endpoint.
+        add_routes(
+            app,
+            RunnableLambda(lambda foo: "hello"),
+            disabled_endpoints=["meow"],  # type: ignore
+            enable_feedback_endpoint=True,
+            path="/config_off",
+        )
+
+    with pytest.raises(ValueError):
+        # meow is not an endpoint.
+        add_routes(
+            app,
+            RunnableLambda(lambda foo: "hello"),
+            enabled_endpoints=["meow"],  # type: ignore
+            enable_feedback_endpoint=True,
+            path="/config_off",
+        )


### PR DESCRIPTION
- Validate endpoints are passed as lists / tuples rather than a string
- Use lists instead of tuples in readme.md for endponts examples
