### PR TITLE
Update API Handler marking some fields as private

### DIFF
--- a/langserve/api_handler.py
+++ b/langserve/api_handler.py
@@ -396,7 +396,7 @@ class _APIHandler:
         runnable: Runnable,
         *,
         path: str = "",
-        base_url: str = "",
+        prefix: str = "",
         input_type: Union[Type, Literal["auto"], BaseModel] = "auto",
         output_type: Union[Type, Literal["auto"], BaseModel] = "auto",
         config_keys: Sequence[str] = ("configurable",),
@@ -417,7 +417,7 @@ class _APIHandler:
         Args:
             runnable: The runnable to serve.
             path: The path to serve the runnable under.
-            base_url: Any prefix that may need to be added to the path
+            prefix: Any prefix that may need to be added to the path
                 to get the full URL for the runnable.
                 This is relevant when the runnable is added to an APIRouter.
             input_type: type to use for input validation.
@@ -463,7 +463,7 @@ class _APIHandler:
 
         self._config_keys = config_keys
         self._path = path
-        self._complete_path = base_url + path
+        self._base_url = prefix + path
         self._include_callback_events = include_callback_events
         self._per_req_config_modifier = per_req_config_modifier
         self._serializer = WellKnownLCSerializer()
@@ -1012,10 +1012,10 @@ class _APIHandler:
 
         feedback_enabled = tracing_is_enabled() and self._enable_feedback_endpoint
 
-        if self._complete_path.endswith("/"):
-            playground_url = self._complete_path + "playground"
+        if self._base_url.endswith("/"):
+            playground_url = self._base_url + "playground"
         else:
-            playground_url = self._complete_path + "/playground"
+            playground_url = self._base_url + "/playground"
 
         return await serve_playground(
             self._runnable.with_config(config),

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -352,12 +352,12 @@ def add_routes(
         _register_path_for_app(app, path)
 
     # Determine the base URL for the playground endpoint
-    base_url = app.prefix if isinstance(app, APIRouter) else ""  # type: ignore
+    prefix = app.prefix if isinstance(app, APIRouter) else ""  # type: ignore
 
     api_handler = _APIHandler(
         runnable,
         path=path,
-        base_url=base_url,
+        prefix=prefix,
         input_type=input_type,
         output_type=output_type,
         config_keys=config_keys,

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -352,7 +352,7 @@ def add_routes(
         _register_path_for_app(app, path)
 
     # Determine the base URL for the playground endpoint
-    base_url = (app.prefix if isinstance(app, APIRouter) else "") + path  # type: ignore
+    base_url = app.prefix if isinstance(app, APIRouter) else ""  # type: ignore
 
     api_handler = _APIHandler(
         runnable,

--- a/langserve/validation.py
+++ b/langserve/validation.py
@@ -26,6 +26,7 @@ from langchain.schema import (
     Generation,
     RunInfo,
 )
+from typing_extensions import Type
 
 from langserve.schema import BatchResponseMetadata, SingletonResponseMetadata
 
@@ -34,7 +35,6 @@ try:
 except ImportError:
     from pydantic import BaseModel, Field, create_model
 
-from typing_extensions import Type, TypedDict
 
 # Type that is either a python annotation or a pydantic model that can be
 # used to validate the input or output of a runnable.
@@ -46,7 +46,7 @@ Validator = Union[Type[BaseModel], type]
 def create_invoke_request_model(
     namespace: str,
     input_type: Validator,
-    config: TypedDict,
+    config: Type[BaseModel],
 ) -> Type[BaseModel]:
     """Create a pydantic model for the invoke request."""
     invoke_request_type = create_model(
@@ -77,7 +77,7 @@ def create_invoke_request_model(
 def create_stream_request_model(
     namespace: str,
     input_type: Validator,
-    config: TypedDict,
+    config: Type[BaseModel],
 ) -> Type[BaseModel]:
     """Create a pydantic model for the stream request."""
     stream_request_model = create_model(
@@ -108,7 +108,7 @@ def create_stream_request_model(
 def create_batch_request_model(
     namespace: str,
     input_type: Validator,
-    config: TypedDict,
+    config: Type[BaseModel],
 ) -> Type[BaseModel]:
     """Create a pydantic model for the batch request."""
     batch_request_type = create_model(
@@ -140,7 +140,7 @@ def create_batch_request_model(
 def create_stream_log_request_model(
     namespace: str,
     input_type: Validator,
-    config: TypedDict,
+    config: Type[BaseModel],
 ) -> Type[BaseModel]:
     """Create a pydantic model for the invoke request."""
     stream_log_request = create_model(


### PR DESCRIPTION
This PR updates API handler to mark some of its fields as private in
preparation for exposing the underlying API handler as public.

Also fixes some incorrect type annotations.
