### PR TITLE
Clean up endpoints

### DIFF
--- a/langserve/api_handler.py
+++ b/langserve/api_handler.py
@@ -1175,7 +1175,7 @@ class APIHandler:
         )
 
     async def create_feedback(
-        self, feedback_create_req: FeedbackCreateRequest, config_hash: str = ""
+        self, feedback_create_req: FeedbackCreateRequest
     ) -> Feedback:
         """Send feedback on an individual run to langsmith
 
@@ -1218,18 +1218,18 @@ class APIHandler:
             comment=feedback_from_langsmith.comment,
         )
 
-    async def _check_feedback_enabled(self, config_hash: str = "") -> None:
+    async def _check_feedback_enabled(self) -> None:
         """Check if feedback is enabled for the runnable.
 
         This endpoint is private since it will be deprecated in the future.
         """
-        if not (await self.check_feedback_enabled(config_hash)):
+        if not (await self.check_feedback_enabled()):
             raise HTTPException(
                 400,
                 "The feedback endpoint is only accessible when LangSmith is "
                 + "enabled on your LangServe server.",
             )
 
-    async def check_feedback_enabled(self, config_hash: str = "") -> bool:
+    async def check_feedback_enabled(self) -> bool:
         """Check if feedback is enabled for the runnable."""
         return self._enable_feedback_endpoint or not tracing_is_enabled()

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -594,29 +594,13 @@ def add_routes(
             )(playground)
 
     if enable_feedback_endpoint:
-        create_feedback = app.post(
+        app.post(
             namespace + "/feedback",
         )(api_handler.create_feedback)
 
-        if endpoint_configuration.is_config_hash_enabled:
-            app.post(
-                namespace + "/c/{config_hash}/feedback",
-            )(create_feedback)
-
-        check_feedback_enabled = app.head(
+        app.head(
             namespace + "/feedback",
         )(api_handler._check_feedback_enabled)
-
-        # Add get version which returns True/False for flow control
-        # instead of 200/400 for flow control
-        app.get(
-            namespace + "/feedback",
-        )(api_handler.check_feedback_enabled)
-
-        if endpoint_configuration.is_config_hash_enabled:  # Is this needed?
-            app.head(
-                namespace + "/c/{config_hash}/feedback",
-            )(check_feedback_enabled)
 
     #######################################
     # Documentation variants of end points.

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -1915,7 +1915,6 @@ async def test_endpoint_configurations() -> None:
         ("POST", "/c/1234/output_schema", {}),
         ("POST", "/c/1234/config_schema", {}),
         ("POST", "/c/1234/playground/index.html", {}),
-        ("POST", "/c/1234/feedback", {}),
     ]
 
     # All endpoints disabled


### PR DESCRIPTION
Remove feedback related endpoints that take a config hash. The feedback endpoints only care about the run_id and the feedback, so a config hash should not be needed.

Also removing the `get` version of checking if feedback is enabled. I'll transition both the UI and the backend in a bit.
