### PR TITLE
Add ability to pass path dependencies through add_routes

### DIFF
--- a/examples/auth/path_dependencies/server.py
+++ b/examples/auth/path_dependencies/server.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""An example that shows how to use path dependencies for authentication.
+
+The path dependencies are applied to all the routes added by the `add_routes`.
+
+To keep this example brief, we're providing a placeholder verify_token function
+that shows how to use path dependencies.
+
+To implement proper auth, please see the FastAPI docs:
+
+* https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-in-path-operation-decorators/
+* https://fastapi.tiangolo.com/tutorial/dependencies/
+* https://fastapi.tiangolo.com/tutorial/security/
+"""  # noqa: E501
+
+from fastapi import Depends, FastAPI, Header, HTTPException
+from langchain_core.runnables import RunnableLambda
+from typing_extensions import Annotated
+
+from langserve import add_routes
+
+
+async def verify_token(x_token: Annotated[str, Header()]) -> None:
+    """Verify the token is valid."""
+    # Replace this with your actual authentication logic
+    if x_token != "secret-token":
+        raise HTTPException(status_code=400, detail="X-Token header invalid")
+
+
+app = FastAPI()
+
+
+def add_one(x: int) -> int:
+    """Add one to an integer."""
+    return x + 1
+
+
+chain = RunnableLambda(add_one)
+
+
+add_routes(
+    app,
+    chain,
+    dependencies=[Depends(verify_token)],
+)
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="localhost", port=8000)

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -29,7 +29,7 @@ try:
     from fastapi import APIRouter, Depends, FastAPI, Request, Response
 except ImportError:
     # [server] extra not installed
-    APIRouter = FastAPI = Request = Response = Any
+    APIRouter = Depends = FastAPI = Request = Response = Any
 
 # A function that that takes a config and a raw request
 # and updates the config based on the request.

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -1992,7 +1992,10 @@ async def test_endpoint_configurations() -> None:
             # It may still be 4xx due to incorrect payload etc, but
             # we don't care, we just want to make sure that the endpoint
             # is enabled.
-            assert response.status_code != 404, f"endpoint {endpoint} should be on"
+            assert response.status_code not in {
+                404,
+                405,
+            }, f"endpoint {endpoint} should be on"
 
     # Config disabled
     async with get_async_test_client(app, raise_app_exceptions=False) as async_client:
@@ -2008,7 +2011,10 @@ async def test_endpoint_configurations() -> None:
                 response = await async_client.request(
                     method, "/config_off" + endpoint, json=payload
                 )
-                assert response.status_code != 404, f"endpoint {endpoint} should be on"
+                assert response.status_code not in {
+                    404,
+                    405,
+                }, f"endpoint {endpoint} should be on"
 
     with pytest.raises(ValueError):
         # Passing "invoke" instead of ["invoke"]
@@ -2095,7 +2101,7 @@ async def test_path_dependencies() -> None:
             response = await async_client.request(
                 method, endpoint, json=payload, headers={"X-Token": "secret-token"}
             )
-            assert response.status_code != 422, (
+            assert response.status_code not in {422, 405, 404}, (
                 f"Failed test case: ({method}, {endpoint}, {payload}) "
                 f"with {response.text}. "
                 f"Should not return 422 status code since we are passing the header."

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -2103,9 +2103,10 @@ async def test_path_dependencies() -> None:
         for method, endpoint, payload in endpoints_with_payload:
             response = await async_client.request(method, endpoint, json=payload)
             # Missing required header
-            assert (
-                response.status_code == 422
-            ), f"Should fail on {endpoint} since we are missing the header. Test case: ({method}, {endpoint}, {payload}) with {response.text}"
+            assert response.status_code == 422, (
+                f"Should fail on {endpoint} since we are missing the header. "
+                f"Test case: ({method}, {endpoint}, {payload}) with {response.text}"
+            )
 
             response = await async_client.request(
                 method, endpoint, json=payload, headers={"X-Token": "secret-token"}

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -6,7 +6,6 @@ from asyncio import AbstractEventLoop
 from contextlib import asynccontextmanager, contextmanager
 from enum import Enum
 from typing import (
-    Annotated,
     Any,
     Dict,
     Iterable,
@@ -35,7 +34,7 @@ from langchain.schema.runnable.utils import ConfigurableField, Input, Output
 from langsmith import schemas as ls_schemas
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
-from typing_extensions import TypedDict
+from typing_extensions import Annotated, TypedDict
 
 from langserve import api_handler
 from langserve.api_handler import (


### PR DESCRIPTION
This PR adds the ability to specify path dependencies through add_routes.

This is useful whenever the dependencies need to be solved, but their return
value is not important; e.g., this could be a simple way to do authentication,
assuming all authenticated users have the same authorization privilegies.
