### PR TITLE
Example: Add per user retriever with auth using APIHandler

### DIFF
--- a/examples/auth/api_handler/client.ipynb
+++ b/examples/auth/api_handler/client.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Client\n",
+    "\n",
+    "This is an example client that interacts with the server that has \"auth\".\n",
+    "\n",
+    "Please reference appropriate documentation in the server code and in FastAPI to actually make this secure.\n",
+    "\n",
+    "\n",
+    "**ATTENTION** Only the invoke endpoint has been defined by the server! \n",
+    "So batch/stream won't work. If you want to add stream and batch, you can do so as well on the server side.\n",
+    "The server is implemented using the APIHandler, it's more flexible, but does require a bit more code. :)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Login as Alice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "response = requests.post(\"http://localhost:8000/token\", data={\"username\": \"alice\", \"password\": \"secret1\"})\n",
+    "result = response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "token = result['access_token']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "inputs = {\"input\": \"hello\"}\n",
+    "response = requests.post(\"http://localhost:8000/my_runnable/invoke\", \n",
+    "    json={\n",
+    "        'input': 'hello',\n",
+    "    },\n",
+    "    headers={\n",
+    "        'Authorization': f\"Bearer {token}\"\n",
+    "    }\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'output': [{'page_content': 'cats like mice',\n",
+       "   'metadata': {'owner_id': 'alice'},\n",
+       "   'type': 'Document'},\n",
+       "  {'page_content': 'cats like cheese',\n",
+       "   'metadata': {'owner_id': 'alice'},\n",
+       "   'type': 'Document'}],\n",
+       " 'callback_events': [],\n",
+       " 'metadata': {'run_id': '1732c9aa-c6d3-4736-b8ca-01265fa8ba06'}}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "You can also interact with this via the RemoteRunnable interface (to use in other chains)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from langserve import RemoteRunnable\n",
+    "\n",
+    "remote_runnable = RemoteRunnable(\"http://localhost:8000/my_runnable\", headers={\"Authorization\": f\"Bearer {token}\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Document(page_content='cats like mice', metadata={'owner_id': 'alice'}),\n",
+       " Document(page_content='cats like cheese', metadata={'owner_id': 'alice'})]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "await remote_runnable.ainvoke(\"cat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Login as John"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "response = requests.post(\"http://localhost:8000/token\", data={\"username\": \"john\", \"password\": \"secret2\"})\n",
+    "token = response.json()['access_token']\n",
+    "remote_runnable = RemoteRunnable(\"http://localhost:8000/my_runnable\", headers={\"Authorization\": f\"Bearer {token}\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Document(page_content='i like walks by the ocean', metadata={'owner_id': 'john'}),\n",
+       " Document(page_content='dogs like sticks', metadata={'owner_id': 'john'}),\n",
+       " Document(page_content='my favorite food is cheese', metadata={'owner_id': 'john'})]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "await remote_runnable.ainvoke(\"water\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -399,7 +399,7 @@ def add_routes(
             # When using pydantic v2, we cannot generate openapi docs for
             # the invoke/batch/stream/stream_log endpoints since the underlying
             # models are from the pydantic.v1 namespace and cannot be supported
-            # by fastapi's.
+            # by FastAPI's.
             # https://github.com/tiangolo/fastapi/issues/10360
             default_endpoint_tags = {
                 "name": route_tags[0] if route_tags else "default",


### PR DESCRIPTION
This PR adds an example that shows how to implement per user logic with sample Auth using the APIHandler primitive.

Another example for: https://github.com/langchain-ai/langserve/issues/354