### PR TITLE
docs: update code example, fix deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ the Anthropic model to tell a joke about a topic.
 #!/usr/bin/env python
 from fastapi import FastAPI
 from langchain.prompts import ChatPromptTemplate
-from langchain.chat_models import ChatAnthropic, ChatOpenAI
+from langchain_community.chat_models import ChatAnthropic
+from langchain_openai import ChatOpenAI
 from langserve import add_routes
 
 app = FastAPI(


### PR DESCRIPTION
```
LangChainDeprecationWarning: The class `langchain_community.chat_models.openai.ChatOpenAI` was deprecated in langchain-community 0.0.10 and will be removed in 0.2.0. An updated version of the class exists in the langchain-openai package and should be used instead. To use it run `pip install -U langchain-openai` and import as `from langchain_openai import ChatOpenAI`.
```