### PR TITLE
Strip internal keys from metadata

### DIFF
--- a/langserve/api_handler.py
+++ b/langserve/api_handler.py
@@ -1177,7 +1177,7 @@ class APIHandler:
                         in self._names_in_stream_allow_list
                     ):
                         # Strip internal metadata from the event
-                        event['metadata'] = _strip_standard_metadata(event['metadata'])
+                        event["metadata"] = _strip_standard_metadata(event["metadata"])
                         yield {
                             # EventSourceResponse expects a string for data
                             # so after serializing into bytes, we decode into utf-8

--- a/langserve/api_handler.py
+++ b/langserve/api_handler.py
@@ -95,6 +95,11 @@ PerRequestConfigModifier = Union[
 ]
 
 
+def _strip_standard_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip standard metadata from the given metadata dict."""
+    return {k: v for k, v in metadata.items() if not k.startswith("__")}
+
+
 async def _unpack_request_config(
     *client_sent_configs: Union[BaseModel, Mapping, str],
     config_keys: Sequence[str],
@@ -1171,7 +1176,8 @@ class APIHandler:
                         or self._runnable.config.get("run_name")
                         in self._names_in_stream_allow_list
                     ):
-                        # Temporary adapter
+                        # Strip internal metadata from the event
+                        event['metadata'] = _strip_standard_metadata(event['metadata'])
                         yield {
                             # EventSourceResponse expects a string for data
                             # so after serializing into bytes, we decode into utf-8

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -2204,6 +2204,10 @@ async def test_astream_events(async_remote_runnable: RemoteRunnable) -> None:
         for event in events:
             assert "run_id" in event
             del event["run_id"]
+            # Assert that we don't include any "internal" metadata
+            # in the events
+            for k, v in event["metadata"].items():
+                assert not k.startswith("__")
             assert "metadata" in event
             del event["metadata"]
 


### PR DESCRIPTION
This PR will make sure that we strip internal information from the event
metadata.
