### PR TITLE
Examples: Add chat widget to agent

### DIFF
--- a/examples/agent_with_history/server.py
+++ b/examples/agent_with_history/server.py
@@ -37,7 +37,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
 from langserve import add_routes
-from langserve.pydantic_v1 import BaseModel
+from langserve.pydantic_v1 import BaseModel, Field
 
 prompt = ChatPromptTemplate.from_messages(
     [
@@ -122,7 +122,16 @@ app = FastAPI(
 # is lacking in schemas.
 class Input(BaseModel):
     input: str
-    chat_history: List[Union[HumanMessage, AIMessage, FunctionMessage]]
+    # The field extra defines a chat widget.
+    # Please see documentation about widgets in the main README.
+    # The widget is used in the playground.
+    # Keep in mind that playground support for agents is not great at the moment.
+    # To get a better experience, you'll need to customize the streaming output
+    # for now.
+    chat_history: List[Union[HumanMessage, AIMessage, FunctionMessage]] = Field(
+        ...,
+        extra={"widget": {"type": "chat", "input": "input", "output": "output"}},
+    )
 
 
 class Output(BaseModel):

--- a/examples/chat_with_persistence/server.py
+++ b/examples/chat_with_persistence/server.py
@@ -18,9 +18,9 @@ from langchain.memory import FileChatMessageHistory
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.runnables.history import RunnableWithMessageHistory
-from typing_extensions import TypedDict
 
 from langserve import add_routes
+from langserve.pydantic_v1 import BaseModel, Field
 
 
 def _is_valid_identifier(value: str) -> bool:
@@ -79,11 +79,19 @@ prompt = ChatPromptTemplate.from_messages(
 chain = prompt | ChatAnthropic(model="claude-2")
 
 
-class InputChat(TypedDict):
+class InputChat(BaseModel):
     """Input for the chat endpoint."""
 
-    human_input: str
-    """Human input"""
+    # The field extra defines a chat widget.
+    # As of 2024-02-05, this chat widget is not fully supported.
+    # It's included in documentation to show how it should be specified, but
+    # will not work until the widget is fully supported for history persistence
+    # on the backend.
+    human_input: str = Field(
+        ...,
+        description="The human input to the chat system.",
+        extra={"widget": {"type": "chat", "input": "human_input"}},
+    )
 
 
 chain_with_history = RunnableWithMessageHistory(


### PR DESCRIPTION
* Adds a chat widget to the agent
* Adds chat widget to the chat with history persisted on the user side (but
  this is not yet supported by the playground)
