### PR TITLE
Fix: Pass dependencies to doc endpont for stream

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -826,6 +826,7 @@ def add_routes(
                 include_in_schema=True,
                 tags=route_tags,
                 name=_route_name("stream"),
+                dependencies=dependencies,
                 description=(
                     "This endpoint allows to stream the output of the runnable. "
                     "The endpoint uses a server sent event stream to stream the "


### PR DESCRIPTION
This PR fixes a bug that wasn't making dependency information
show up for the documentation of the stream endpoint.

The dependencies were correctly applied for the endpoint itself,
so only the documentation is affected for /stream endpoint.

