### PR TITLE
Allow accepting run ids by the server

### DIFF
--- a/langserve/api_handler.py
+++ b/langserve/api_handler.py
@@ -1087,6 +1087,7 @@ class APIHandler:
         """
         err_event = {}
         validation_exception: Optional[BaseException] = None
+        run_id = None
         try:
             config, input_ = await self._get_config_and_input(
                 request,
@@ -1094,6 +1095,7 @@ class APIHandler:
                 endpoint="stream",
                 server_config=server_config,
             )
+            run_id = config["run_id"]
         except BaseException as e:
             validation_exception = e
             if isinstance(e, RequestValidationError):
@@ -1113,9 +1115,7 @@ class APIHandler:
                     ),
                 }
 
-        run_id = config["run_id"]
-
-        if self._token_feedback_enabled:
+        if self._token_feedback_enabled and not validation_exception:
             # Create task to create a presigned feedback token
             feedback_key: Optional[str] = self._token_feedback_config["key_configs"][0][
                 "key"
@@ -1316,6 +1316,7 @@ class APIHandler:
         """Stream events from the runnable."""
         err_event = {}
         validation_exception: Optional[BaseException] = None
+        run_id = None
         try:
             config, input_ = await self._get_config_and_input(
                 request,
@@ -1323,6 +1324,7 @@ class APIHandler:
                 endpoint="stream_events",
                 server_config=server_config,
             )
+            run_id = config["run_id"]
         except BaseException as e:
             validation_exception = e
             if isinstance(e, RequestValidationError):
@@ -1341,8 +1343,6 @@ class APIHandler:
                         {"status_code": 500, "message": "Internal Server Error"}
                     ),
                 }
-
-        run_id = config["run_id"]
 
         try:
             body = await request.json()
@@ -1366,7 +1366,7 @@ class APIHandler:
 
         feedback_key: Optional[str]
 
-        if self._token_feedback_enabled:
+        if self._token_feedback_enabled and not validation_exception:
             # Create task to create a presigned feedback token
             feedback_key: str = self._token_feedback_config["key_configs"][0]["key"]
             feedback_coro = run_in_executor(

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -2983,51 +2983,25 @@ async def test_scoped_feedback() -> None:
             for event in events:
                 if "data" in event and "run_id" in event["data"]:
                     del event["data"]["run_id"]
-            assert events == [
-                {
-                    "data": {
-                        "data": {"input": "hello"},
-                        "event": "on_chain_start",
-                        "metadata": {},
-                        "name": "RunnableLambda",
-                        "tags": [],
-                    },
-                    "type": "data",
+
+            # Find the metadata event and pull it out
+            metadata_event = None
+            for event in events:
+                if event["type"] == "metadata":
+                    metadata_event = event
+
+            assert metadata_event == {
+                "data": {
+                    "feedback_tokens": [
+                        {
+                            "expires_at": "2023-01-01T00:00:00",
+                            "key": "foo",
+                            "token_url": "feedback_id",
+                        }
+                    ]
                 },
-                {
-                    "data": {
-                        "feedback_tokens": [
-                            {
-                                "expires_at": "2023-01-01T00:00:00",
-                                "key": "foo",
-                                "token_url": "feedback_id",
-                            }
-                        ]
-                    },
-                    "type": "metadata",
-                },
-                {
-                    "data": {
-                        "data": {"chunk": "hello"},
-                        "event": "on_chain_stream",
-                        "metadata": {},
-                        "name": "RunnableLambda",
-                        "tags": [],
-                    },
-                    "type": "data",
-                },
-                {
-                    "data": {
-                        "data": {"output": "hello"},
-                        "event": "on_chain_end",
-                        "metadata": {},
-                        "name": "RunnableLambda",
-                        "tags": [],
-                    },
-                    "type": "data",
-                },
-                {"type": "end"},
-            ]
+                "type": "metadata",
+            }
 
 
 async def test_passing_run_id_from_client() -> None:


### PR DESCRIPTION
This PR allows to turn on a configuration that makes the server accept client provided run ids.

The server needs to be started with

`add_routes(..., config_keys=['run_id'])`

And a client will then be able to make a request with `config={"run_id": uuid4}`
