### PR TITLE
Improve error message if user isn't passing a Runnable to add_routes

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -392,6 +392,15 @@ def add_routes(
               the README in langserve for more details about constraints (e.g.,
               which message types are supported etc.)
     """  # noqa: E501
+    if not isinstance(runnable, Runnable):
+        raise TypeError(
+            f"Expected a Runnable, got {type(runnable)}. "
+            f"The second argument to add_routes should be a Runnable instance."
+            f"add_route(app, runnable, ...) is the correct usage."
+            f"Please make sure that you are using a runnable which is an instance of "
+            f"langchain_core.runnables.Runnable."
+        )
+
     endpoint_configuration = _EndpointConfiguration(
         enabled_endpoints=enabled_endpoints,
         disabled_endpoints=disabled_endpoints,

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -3056,3 +3056,11 @@ async def test_passing_run_id_from_client() -> None:
         )
         events = _decode_eventstream(response.text)
         assert events[0]["data"]["run_id"] == str(run_id)
+
+
+async def test_passing_bad_runnable_to_add_routes() -> None:
+    """test passing a bad type."""
+    with pytest.raises(TypeError) as e:
+        add_routes(FastAPI(), "not a runnable")
+
+    assert e.match("Expected a Runnable, got <class 'str'>")


### PR DESCRIPTION
After this PR a better error message will be surfaced to add_routes if a user passes something that's not a runnable.

This currently occurs a lot when using the langchain cli as the lanchain cli creates an empty app with a palceholder value of NotImplemented for the runnable.
