### PR TITLE
Add check for valid playground assets path in playground tests

### DIFF
--- a/tests/unit_tests/test_api_playground.py
+++ b/tests/unit_tests/test_api_playground.py
@@ -45,6 +45,9 @@ async def test_serve_playground_with_api_router() -> None:
     async with AsyncClient(app=app, base_url="http://localhost:9999") as client:
         response = await client.get("/langserve_runnables/chat/playground/index.html")
         assert response.status_code == 200
+        assert (
+            'src="/langserve_runnables/chat/playground/assets/' in response.content.decode()
+        ), "html should contain reference to valid playground assets path"
 
 
 async def test_serve_playground_with_api_router_in_api_router() -> None:
@@ -67,6 +70,9 @@ async def test_serve_playground_with_api_router_in_api_router() -> None:
     async with AsyncClient(app=app, base_url="http://localhost:9999") as client:
         response = await client.get("/parent/bar/foo/playground/index.html")
         assert response.status_code == 200
+        assert (
+            'src="/parent/bar/foo/playground/assets/' in response.content.decode()
+        ), "html should contain reference to valid playground assets path"
 
 
 async def test_root_path_on_playground() -> None:


### PR DESCRIPTION
Update playground tests to check for the correct playground assets path in index.html. #578 