### PR TITLE
Fixes associated with feedback endpoint

### DIFF
--- a/langserve/schema.py
+++ b/langserve/schema.py
@@ -116,7 +116,7 @@ class BaseFeedback(BaseModel):
 class FeedbackCreateRequestTokenBased(BaseModel):
     """Shared information between create requests of feedback and feedback objects."""
 
-    token_or_url: UUID
+    token_or_url: Union[UUID, str]
     """The associated run ID this feedback is logged for."""
 
     score: Optional[Union[float, int, bool]] = None


### PR DESCRIPTION
- Fixes langsmith client not being enabled if token feedback was specified
- Add unit test for token feedback endpoint
- Fix schema for token feedback to accept a str in addition to a UUID
- Add metadata even to astream log with token feedback information
