### PR TITLE
Add serve() entrypoint

### DIFF
--- a/langserve/__init__.py
+++ b/langserve/__init__.py
@@ -7,7 +7,7 @@ to be considered private and subject to change without notice.
 from langserve.api_handler import APIHandler
 from langserve.client import RemoteRunnable
 from langserve.schema import CustomUserType
-from langserve.server import add_routes
+from langserve.server import add_routes, serve
 from langserve.version import __version__
 
 __all__ = [
@@ -16,4 +16,5 @@ __all__ = [
     "add_routes",
     "__version__",
     "CustomUserType",
+    "serve",
 ]

--- a/langserve/server.py
+++ b/langserve/server.py
@@ -8,6 +8,7 @@ FastAPI app or APIRouter.
 import weakref
 from typing import (
     Any,
+    Dict,
     Literal,
     Optional,
     Sequence,
@@ -1104,3 +1105,22 @@ def add_routes(
                     ),
                     dependencies=dependencies,
                 )(_stream_events_docs)
+
+
+def serve(
+    runnables: Union[Runnable, Dict[str, Runnable]],
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    **kwargs: Any,
+) -> None:
+    import uvicorn
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    if isinstance(runnables, Runnable):
+        runnables = {"": runnables}
+    for path, runnable in runnables.items():
+        add_routes(app, runnable, path=path, **kwargs)
+
+    uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
- creates a fastapi app
- mounts one or more runnables
- starts the server with uvicorn