### PR TITLE
fix: correct the request URL construction in playground

### DIFF
--- a/langserve/playground/src/utils/url.ts
+++ b/langserve/playground/src/utils/url.ts
@@ -7,8 +7,9 @@ export function getStateFromUrl(path: string) {
     basePath = basePath.slice(0, -1);
   }
 
-  if (basePath.endsWith("/playground")) {
-    basePath = basePath.slice(0, -"/playground".length);
+  const newBasePath = basePath.replace(/\/playground(\/index.html)?$/, "");
+  if (newBasePath !== basePath) {
+    basePath = newBasePath;
   }
 
   // check if we can omit the last segment


### PR DESCRIPTION
Previously, the playground was building request URLs by removing the `playground` suffix and appending `stream_log`. This worked when the URL ended with `playground`, but failed for URLs ending with `index.html`. The issue was the code only checked for URLs ending with `playground` and did not account for `index.html` endings.