### PR TITLE
[RFC] Introduce Pluto as a deployment option for LangServe apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,17 @@ gcloud run deploy [your-service-name] --source . --port 8001 --allow-unauthentic
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/pW9tXP?referralCode=c-aq4K)
 
+#### Deploy using Pluto
+
+You can deploy a LangServe app on AWS using [Pluto](https://github.com/pluto-lang/pluto) with a few
+modifications and a single command:
+
+```
+pluto deploy
+```
+
+To get started, check out the guide on [Deploying a LangServe app on AWS using Pluto](https://github.com/pluto-lang/pluto/tree/main/examples/deploy-langserve-to-aws).
+
 ## Pydantic
 
 LangServe provides support for Pydantic 2 with some limitations.


### PR DESCRIPTION
Hi, I am working on a project called Pluto, which is a cloud-native application development tool. It simplifies cloud application development by providing a streamlined programming interface for leveraging cloud features and building business logic. Developers can define their dependent services and resources, such as Lambda, Bucket, and etc. by defining a variable. Pluto will automatically provision the resources and deploy the application to the cloud. Developer use the Pluto without need to learn complex cloud technologies, such as Terraform, Pulumi or AWS CDK.

To help the LangServe app developers that don't have much experience with cloud to deploy their apps on the cloud. I have added a new section in the README.md file to introduce Pluto as a deployment option for LangServe apps.

In summary, there are two steps to adapt the LangServe application to the Pluto application so that Pluto can deploy it to AWS.

1. First, put the code related to the FastAPI app into a function and make this function return the FastAPI app instance. Here we assume that the function name is `return_fastapi_app`.
2. Then, replace the entire if `__name__ == "__main__"` code block with the following 4 statements. The `router_name` can be modified. It is related to the name of the Api Gateway instance created on AWS.

```python
from mangum import Mangum
from pluto_client import Router

router = Router("router_name")
router.all("/*", lambda *args, **kwargs: Mangum(return_fastapi_app(), api_gateway_base_path="/dev")(*args, **kwargs), raw=True)
```

For more information, please refer to [this link](https://pluto-lang.vercel.app/cookbook/deploy-langserve-to-aws).

I'm not entirely sure if this is an optimal interface for developing LangServe applications. Do you believe it's an effective method for LangServe app developers to deploy their applications in the cloud? I would appreciate any suggestions or queries that you might have. Thank you!