### PR TITLE
resolve more warnings in unit tests

### DIFF
--- a/tests/unit_tests/test_api_playground.py
+++ b/tests/unit_tests/test_api_playground.py
@@ -1,5 +1,6 @@
 """Test the playground API."""
 
+import httpx
 from fastapi import APIRouter, FastAPI
 from httpx import AsyncClient
 from langchain_core.runnables import RunnableLambda
@@ -15,7 +16,9 @@ async def test_serve_playground() -> None:
         RunnableLambda(lambda foo: "hello"),
     )
 
-    async with AsyncClient(app=app, base_url="http://localhost:9999") as client:
+    async with AsyncClient(
+        base_url="http://localhost:9999", transport=httpx.ASGITransport(app=app)
+    ) as client:
         response = await client.get("/playground/index.html")
         assert response.status_code == 200
         # Test that we can't access files that do not exist.
@@ -42,7 +45,9 @@ async def test_serve_playground_with_api_router() -> None:
 
     app.include_router(router)
 
-    async with AsyncClient(app=app, base_url="http://localhost:9999") as client:
+    async with AsyncClient(
+        base_url="http://localhost:9999", transport=httpx.ASGITransport(app=app)
+    ) as client:
         response = await client.get("/langserve_runnables/chat/playground/index.html")
         assert response.status_code == 200
 
@@ -64,7 +69,9 @@ async def test_serve_playground_with_api_router_in_api_router() -> None:
     # Now add parent router to the app
     app.include_router(parent_router)
 
-    async with AsyncClient(app=app, base_url="http://localhost:9999") as client:
+    async with AsyncClient(
+        base_url="http://localhost:9999", transport=httpx.ASGITransport(app=app)
+    ) as client:
         response = await client.get("/parent/bar/foo/playground/index.html")
         assert response.status_code == 200
 
@@ -88,7 +95,9 @@ async def test_root_path_on_playground() -> None:
         )
         app.include_router(router)
 
-        async_client = AsyncClient(app=app, base_url="http://localhost:9999")
+        async_client = AsyncClient(
+            base_url="http://localhost:9999", transport=httpx.ASGITransport(app=app)
+        )
 
         response = await async_client.get("/chat/playground/index.html")
         assert response.status_code == 200

--- a/tests/unit_tests/test_server_client.py
+++ b/tests/unit_tests/test_server_client.py
@@ -457,7 +457,10 @@ async def test_server_astream_events(app: FastAPI) -> None:
 
 async def test_server_bound_async(app_for_config: FastAPI) -> None:
     """Test the server directly via HTTP requests."""
-    async_client = AsyncClient(app=app_for_config, base_url="http://localhost:9999")
+    async_client = AsyncClient(
+        base_url="http://localhost:9999",
+        transport=httpx.ASGITransport(app=app_for_config),
+    )
     config_hash = LZString.compressToEncodedURIComponent(json.dumps({"tags": ["test"]}))
 
     # Test invoke
@@ -1105,7 +1108,9 @@ async def test_config_keys_validation(mocker: MockerFixture) -> None:
         input_type=int,
         config_keys=["metadata"],
     )
-    async with AsyncClient(app=app, base_url="http://localhost:9999") as async_client:
+    async with AsyncClient(
+        base_url="http://localhost:9999", transport=httpx.ASGITransport(app=app)
+    ) as async_client:
         server_runnable_spy = mocker.spy(server_runnable, "ainvoke")
         response = await async_client.post(
             "/invoke",
@@ -1289,7 +1294,9 @@ async def test_openapi_docs_with_identical_runnables(
         config_keys=["tags"],
     )
 
-    async with AsyncClient(app=app, base_url="http://localhost:9999") as async_client:
+    async with AsyncClient(
+        base_url="http://localhost:9999", transport=httpx.ASGITransport(app=app)
+    ) as async_client:
         response = await async_client.get("/openapi.json")
         assert response.status_code == 200
 
@@ -1423,7 +1430,9 @@ async def test_input_config_output_schemas(event_loop: AbstractEventLoop) -> Non
     )
     add_routes(app, template, path="/prompt_2", config_keys=["tags", "configurable"])
 
-    async with AsyncClient(app=app, base_url="http://localhost:9999") as async_client:
+    async with AsyncClient(
+        base_url="http://localhost:9999", transport=httpx.ASGITransport(app=app)
+    ) as async_client:
         # input schema
         response = await async_client.get("/add_one/input_schema")
         assert response.json() == {"title": "add_one_input", "type": "integer"}
@@ -1574,7 +1583,9 @@ async def test_input_schema_typed_dict() -> None:
     app = FastAPI()
     add_routes(app, runnable_lambda, input_type=InputType, config_keys=["tags"])
 
-    async with AsyncClient(app=app, base_url="http://localhost:9999") as client:
+    async with AsyncClient(
+        base_url="http://localhost:9999", transport=httpx.ASGITransport(app=app)
+    ) as client:
         res = await client.get("/input_schema")
         if PYDANTIC_VERSION < (2, 9):
             assert res.json() == {


### PR DESCRIPTION
Migrated using gritql 

`AsyncClient(app=$y, $x)` => `AsyncClient($x, transport= httpx.ASGITransport(app=$y))`
