### PR TITLE
docs: update local link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > [!WARNING]
 > We recommend using LangGraph Platform rather than LangServe for new projects.
 >
-> Please see the [LangGraph Platform Migration Guide](MIGRATION.md) for more information.
+> Please see the [LangGraph Platform Migration Guide](./MIGRATION.md) for more information.
 >
 > We will continue to accept bug fixes for LangServe from the community; however, we
 > will not be accepting new feature contributions.


### PR DESCRIPTION
LangChain doc builds are currently [broken](https://vercel.com/langchain/langchain/ExxE3a6SSZVa7RSRUDB3mzHDpsvV?filter=errors).

- LangChain docs page hosts LangServe readme: https://python.langchain.com/docs/langserve/;
- The readme is [downloaded from github](https://github.com/langchain-ai/langchain/blob/22a8652eccd9023cd41ea0f6924575ce87c28756/docs/Makefile#L49) when docs are built;
- A [script](https://github.com/langchain-ai/langchain/blob/master/docs/scripts/resolve_local_links.py) resolves local links in the readme to point to the LangServe github.

This script assumes local links are prefixed with `./`