### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,7 +773,7 @@ You can also specify a list of messages as your a parameter directly, as shown i
 ```python
 prompt = ChatPromptTemplate.from_messages(
     [
-        ("system", "You are a helpful assisstant named Cob."),
+        ("system", "You are a helpful assistant named Cob."),
         MessagesPlaceholder(variable_name="messages"),
     ]
 )


### PR DESCRIPTION
Hey, our tool caught a few typos in your repository.

Also, a few typos on your site like 'nad'. Here is your error report:
 https://triplechecker.com/s/L5KPLF/langchain.com

Hope it's helpful!
