### PR TITLE
fix: support pydantic v2 for the FastAPI docs page (compatible with v1)

### DIFF
--- a/langserve/server.py
+++ b/langserve/server.py
@@ -29,10 +29,10 @@ from langserve.api_handler import (
 from langserve.serialization import Serializer
 
 try:
-    from fastapi import APIRouter, Depends, FastAPI, Request, Response, Body
+    from fastapi import APIRouter, Body, Depends, FastAPI, Request, Response
 except ImportError:
     # [server] extra not installed
-    APIRouter = Depends = FastAPI = Request = Response = Body = Any
+    APIRouter = Body = Depends = FastAPI = Request = Response = Any
 
 # A function that that takes a config and a raw request
 # and updates the config based on the request.


### PR DESCRIPTION
This fix adds support for showing the FastAPI docs with pydantic v2; the code is also compatible with pydantic v1.

See https://github.com/langchain-ai/langchain/issues/32097 for the details of the problem.

In short, pydantic v1 uses ``Annotated[Model, Model]`` style, while the new version (v2) prefers ``Annotated[Model, Body(...)]`` for optional fields.
