### PR TITLE
Update Python version matrix in workflow

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"


### PR DESCRIPTION
Removed Python 3.8 from the workflow matrix.