### PR TITLE
fix: update FastAPI to >=0.120.2 to address CVE-2025-62727

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -169,6 +169,18 @@ dev = ["attribution (==1.7.1)", "black (==24.3.0)", "build (>=1.2)", "coverage[t
 docs = ["sphinx (==8.1.3)", "sphinx-mdinclude (==0.6.1)"]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.3"
+description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
+optional = false
+python-versions = ">=3.8"
+groups = ["main", "dev", "examples"]
+files = [
+    {file = "annotated_doc-0.0.3-py3-none-any.whl", hash = "sha256:348ec6664a76f1fd3be81f43dffbee4c7e8ce931ba71ec67cc7f4ade7fbbb580"},
+    {file = "annotated_doc-0.0.3.tar.gz", hash = "sha256:e18370014c70187422c33e945053ff4c286f453a984eba84d0dbfa0c935adeda"},
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
@@ -908,19 +920,20 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "fastapi"
-version = "0.118.0"
+version = "0.120.2"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev", "examples"]
 files = [
-    {file = "fastapi-0.118.0-py3-none-any.whl", hash = "sha256:705137a61e2ef71019d2445b123aa8845bd97273c395b744d5a7dfe559056855"},
-    {file = "fastapi-0.118.0.tar.gz", hash = "sha256:5e81654d98c4d2f53790a7d32d25a7353b30c81441be7d0958a26b5d761fa1c8"},
+    {file = "fastapi-0.120.2-py3-none-any.whl", hash = "sha256:bedcf2c14240e43d56cb9a339b32bcf15104fe6b5897c0222603cb7ec416c8eb"},
+    {file = "fastapi-0.120.2.tar.gz", hash = "sha256:4c5ab43e2a90335bbd8326d1b659eac0f3dbcc015e2af573c4f5de406232c4ac"},
 ]
 
 [package.dependencies]
+annotated-doc = ">=0.0.2"
 pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
-starlette = ">=0.40.0,<0.49.0"
+starlette = ">=0.40.0,<0.50.0"
 typing-extensions = ">=4.8.0"
 
 [package.extras]
@@ -4727,4 +4740,4 @@ server = ["fastapi", "sse-starlette"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "abf439f4862c7575588cae68704bcf4a231090e4730d788b83c9a1611201dd53"
+content-hash = "cd87efecf89b240c5eed955c5b58a2e7cfba623394ea21d10448c71b0863e86c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["langserve/playground/dist/**/*", "langserve/chat_playground/dist/**/
 [tool.poetry.dependencies]
 python = "^3.9"
 httpx = ">=0.23.0,<1.0"
-fastapi = {version = ">=0.90.1,<1", optional = true}
+fastapi = {version = ">=0.120.2,<1", optional = true}
 sse-starlette = {version = "^1.3.0", optional = true}
 langchain-core = ">=0.3,<2"
 orjson = ">=2,<4"
@@ -20,7 +20,7 @@ pydantic = "^2.7"
 
 [tool.poetry.group.dev.dependencies]
 jupyterlab = "^3.6.1"
-fastapi = ">=0.90.1"
+fastapi = ">=0.120.2"
 sse-starlette = "^1.3.0"
 
 [tool.poetry.group.typing.dependencies]
@@ -41,7 +41,7 @@ pytest-timeout = "^2.2.0"
 [tool.poetry.group.examples.dependencies]
 openai = "^0.28.0"
 uvicorn = {extras = ["standard"], version = "^0.23.2"}
-fastapi = ">=0.90.1"
+fastapi = ">=0.120.2"
 sse-starlette = "^1.3.0"
 
 [tool.poetry.extras]


### PR DESCRIPTION
Updates FastAPI minimum version from 0.90.1 to 0.120.2 across all dependency groups to address Starlette vulnerability CVE-2025-62727.

This updates:
- Main optional dependency
- Dev dependencies
- Examples dependencies
- poetry.lock file

Reference: https://www.cve.org/CVERecord?id=CVE-2025-62727