### PR TITLE
docs: restore IaC/Pulumi section with corrected URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,22 @@ You can deploy to GCP Cloud Run using the following command:
 gcloud run deploy [your-service-name] --source . --port 8001 --allow-unauthenticated --region us-central1 --set-env-vars=OPENAI_API_KEY=your_key
 ```
 
+### Deploy using Infrastructure as Code
+
+#### Pulumi
+
+You can deploy your LangServe server with [Pulumi](https://www.pulumi.com/) using your preferred general purpose language. Below are some quickstart
+examples for deploying LangServe to different cloud providers.
+
+These examples are a good starting point for your own infrastructure as code (IaC) projects. You can easily modify them to suit your needs.
+
+| Cloud | Language   | Repository                                                            | Quickstart                                                                                                                                                  |
+| ----- | ---------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AWS   | dotnet     | https://github.com/pulumi/examples/tree/master/aws-cs-langserve       | [![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-cs-langserve)     |
+| AWS   | golang     | https://github.com/pulumi/examples/tree/master/aws-go-langserve       | [![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-go-langserve)     |
+| AWS   | python     | https://github.com/pulumi/examples/tree/master/aws-py-langserve       | [![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-py-langserve)     |
+| AWS   | typescript | https://github.com/pulumi/examples/tree/master/aws-ts-langserve       | [![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-langserve)     |
+
 ### Community Contributed
 
 #### Deploy to Railway


### PR DESCRIPTION
## Summary

Restores the **Deploy using Infrastructure as Code → Pulumi** section that was removed in 109445b25ef047e1cc1624a83eda2deef03a6c83. That section originated in #491, but the example repository links returned 404 because they were missing the `/tree/master/` path segment required for linking to a subdirectory in a GitHub repo — which is presumably why it was removed.

This PR brings the section back with correctly-formed URLs so each quickstart resolves to the intended example. The `aws-js-langserve` row from the original table is dropped because that example does not exist in `pulumi/examples`.

Verified each linked path exists in `pulumi/examples` (default branch `master`):

- https://github.com/pulumi/examples/tree/master/aws-cs-langserve
- https://github.com/pulumi/examples/tree/master/aws-go-langserve
- https://github.com/pulumi/examples/tree/master/aws-py-langserve
- https://github.com/pulumi/examples/tree/master/aws-ts-langserve

## Test plan

- [x] All four `Repository` URLs resolve (no 404)
- [x] All four `Deploy` button `?template=` URLs use the same valid `/tree/master/` paths
- [x] Section is inserted in the same place it previously lived (between **Deploy to GCP** and **Community Contributed**)